### PR TITLE
Import foreign commit prefixed instead of transplanting the tree

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -115,11 +115,21 @@ command:clone() {
   # Create a tree object from the index:
   local tree_commit="$(git write-tree)"
 
+  local parent2_orig_tree="$(git log --max-count=1 --format=%T $upstream_head)"
+
+  # Make a tree object with one dir "subdir" which points to parent2_orig_tree
+  # WARNING: Arbitrary code execution risk here.
+  local parent2_tree="$(
+      (
+        echo -n "040000 ${subdir}";
+        perl -e "print chr(0) . pack q[H*], q[$parent2_orig_tree];";
+      ) | git hash-object -w -t tree --stdin
+  )";
+
   # Create a commit object from the tree:
   update_commit="$(
     action-message |
-    git commit-tree \
-      "$(git log --max-count=1 --format=%T "$upstream_head")"
+    git commit-tree "$parent2_tree"
   )"
 
   # Create a merge commit:


### PR DESCRIPTION
verbatim

This will help avoid problems with rebase.

NOTE: the `.gitrepo` file is still added at the merge stage, and _that_
file will be lost in subsequent rebases/merges.

Also, the equivalent code for `pull` is not in place yet.

It relies on knowledge of the internal format specification for the raw
tree blob object ( what you get if you do `git cat-file tree <TREESHA>` )
and writes one by hand with a bit of ninja tricks from `perl`'s `pack`
function.

This is because silly git, unlike everywhere else in git, stores SHA1s
in TREE blobs in _binary encoding_ instead of in Hex. :(

Tree Blob format is

```
  TYPE SPACE FILENAME NULL BINARYSHA1
```

Where `TYPE` is `040000` for directories/trees.

Signed-off-by: Kent Fredric kentfredric@gmail.com
