### PR TITLE
Fixes the ./test/failing/test.sh failing test case I gave you [improved].

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -186,7 +186,13 @@ command:pull() {
     return
   fi
 
+  #Writes best common-ancestor to $subrepo_parent
+  get-best-common-ancestor-for-merge
+
   OUT=true RUN git log --max-count=1 --format=%T "$upstream_head"
+
+  # Create a new commit object from the upstream subrepo HEAD^{tree} with a parent
+  #  being the best common-ancestor just found:
   OUT=true RUN git commit-tree "$output" -p "$subrepo_parent" -m "$(action-message)"
   update_commit="$output"
 
@@ -194,18 +200,27 @@ command:pull() {
   # This merge can fail, so we need to checkout/merge/remerge instead.
 
   # Merge the update with the subtree strategy:
-  RUN git merge -s recursive -X subtree="$subdir" "$update_commit"
+  RUN git merge --no-ff -s recursive -X subtree="$subdir" -X patience "$update_commit"
 
   OK || { say "git subrepo '$subdir' failed to complete pull"; return; }
-
-  # Prune the merge history to keep things looking clean:
-  RUN git filter-branch -f \
+  # Now, if our subrepo pull has the same parent as the merge commit (i.e. HEAD^ equals HEAD^2^) then we don't need to clean
+  OUT=true RUN git rev-parse HEAD^
+  local headparent="$output"
+  OUT=true RUN git rev-parse HEAD^2^
+  if [ "$headparent" != "$output" ]; then
+    # Prune the merge history to keep things looking clean:
+    RUN git filter-branch -f \
       --parent-filter "sed 's/ -p $subrepo_parent//'" \
       -- "$update_commit"^..HEAD ^HEAD^
 
-  # The update_commit just got rewritten. Need new id:
-  OUT=true RUN git rev-parse HEAD^2
-  update_commit="$output"
+    # The update_commit just got rewritten. Need new id:
+    FAIL=false OUT=true RUN git rev-parse HEAD^2
+    if ! OK; then
+      # This bit helps when there is no second parent- which occurs in certain workflows.
+      FAIL=false OUT=true RUN git rev-parse HEAD
+    fi
+    update_commit="$output"
+  fi
 
   # Update the subdir/.gitrepo file:
   update-gitrepo-file
@@ -229,7 +244,20 @@ command:push() {
   subrepo-checkout
 
   # Attempt to rebase changes onto upstream:
-  FAIL=false RUN git rebase "$upstream_head" "$checkout_branch"
+  FAIL=false RUN git rebase -v "$upstream_head" "$checkout_branch"
+
+  if ! OK; then
+    # Let's rebase a bit more intelligently by using the log to see when the last clone/merge was.
+    # Attempt to rebase A..$checkout_branch onto $upstream_head where A is last clone/merge log entry.
+    RUN git rebase --abort #Abort prior failed rebase.
+    get-last-subrepo-merge-log-entry
+    if [ -n "$output" ]; then
+      FAIL=false RUN git rebase -v --onto "$upstream_head" "$output" "$checkout_branch"
+    else
+      say "Unable to rebase changes from local branch onto subrepo origin as git log entry of last $subdir clone/merge wasn't found."
+      OK=false
+    fi
+  fi
 
   if OK; then
     FAIL=false RUN git push \
@@ -852,6 +880,91 @@ add-subrepo() {
     [[ "$1" =~ ^$path ]] && return
   done
   subrepos+=("$1")
+}
+
+# Writes best common-ancestor to $subrepo_parent
+get-best-common-ancestor-for-merge() {
+  # Writes to $subrepo_parent if relevant clone/pull subrepo log entry found; writes latest match.
+  get-last-original-head-branch-subrepo-log-hash #Note log doesn't contain last subrepo push.
+
+  # Now, if there were no commits since the above we know we have the best common-ancestor:
+  OUT=true RUN git rev-parse "$original_head_branch"
+  if [ "$output" = "$subrepo_parent" ]; then
+    return
+  fi
+
+  # Need to know when to terminate outer loop, must get tree object of above relevant clone/pull commit
+  #  object for the subrepo directory without the .gitrepo file included:
+  local outer_loop_term_tree=""
+  #RUN doesn't support piping completely, must do this process substition to get output of mktree
+  OUT=true RUN git mktree < <(git ls-tree "$subrepo_parent:$subdir" | sed -r '/^.*\.gitrepo.*$/d')
+  if [ -z $output ]; then
+    say "Failed to obtain tree-id of $subdir in relevant clone/pull commit object without .gitrepo file"
+    return
+  fi
+  outer_loop_term_tree="$output"
+
+  # These are the outer loop elements, the tree of each commit in the subrepo branch:
+  OUT=true RUN sed '/commit/d' < <(git rev-list subrepo/$subdir --format="format:%T")
+  local outer_loop_elems="$output"
+
+  # These are the inner loop elements, cached here so they're only looked up once.
+  OUT=true RUN git rev-list "$subrepo_parent".."$original_head_branch" -- "$subdir"
+  local inner_loop_elems="$output"
+
+  # Outer loop we search subrepo/$suddir branch A..HEAD^{tree} where A was found above ($outer_loop_term_tree).
+  # Start at subrepo/$subdir branch and traverse to A as long as match (subrepo push) is not found.
+  # KLUDGE: Note I have a bit of uncertainty about this iteration. Might be a good spot for a new test case.
+  for o in $outer_loop_elems
+  do
+    if [ "$o" = "$outer_loop_term_tree" ]; then
+       break #No need to continue, now we know $subrepo_parent is best common-ancestor.
+    fi
+
+    # Inner loop we search $original_head_branch branch B..HEAD where B is $subrepo_parent found earlier.
+    for i in $inner_loop_elems
+    do
+      OUT=true RUN git mktree < <(git ls-tree "$i:$subdir" | sed -r '/^.*\.gitrepo.*$/d')
+      if [ -z "$output" ]; then
+        say "Failed to obtain tree-id of $subdir in $i without .gitrepo file"
+        continue
+      fi
+      if [ "$output" = "$o" ]; then
+        # We have discovered that the subrepo had been pushed to from $original_head_branch since the last clone/pull.
+        #  We know that $i is the best common ancestor!
+        subrepo_parent="$i"
+        return
+      fi
+    done
+  done
+}
+
+# Writes to $subrepo_parent if relevant subrepo log entry found; writes latest match.
+get-last-original-head-branch-subrepo-log-hash() {
+  # First try the log for pull/clone entries.  Note no push entries are possible in
+  #  the log, so we must search for that later as it would be the best
+  #  common-ancestor candidate as git won't automatically select it during the merge.
+  FAIL=false OUT=true RUN git log --grep="git subrepo pull $subdir" -n 1 --pretty="format:%H"
+  if [ -z "$output" ]; then
+    # TODO: "subrepo clone.*$subdir" should better match what is written by action-message()"
+    FAIL=false OUT=true RUN git log --grep="subrepo clone.*$subdir" -n 1 --pretty="format:%H"
+  fi
+  if [ -n "$output" ]; then
+    subrepo_parent="$output" #AKA common-ancestor for merge to be done soon.
+  else
+    say "Failed to obtain last subrepo log entry."
+  fi
+}
+
+get-last-subrepo-merge-log-entry() {
+  # Get last subrepo merge commit to the local branch for $subdir
+  # TODO: This would match subrepos in $subdir as well! Need to resolve.
+  FAIL=false OUT=true RUN git log --grep="Merge subrepo commit" -n 1 --pretty="format:%H"
+  if [ -z "$output" ]; then
+    # The user hadn't pushed/pulled $subdir before, so they must have only cloned.
+    # TODO: "subrepo clone.*$subdir" should better match what is written by action-message()"
+    FAIL=false OUT=true RUN git log --grep="subrepo clone.*$subdir" -n 1 --pretty="format:%H"
+  fi
 }
 
 # Smart command runner

--- a/test/failing/test.sh
+++ b/test/failing/test.sh
@@ -11,22 +11,21 @@ fi
 home="$(dirname $0)"
 home="${home:-.}"
 cd "$home"
-rm -fr p1 p2 lib lib.git
+rm -fr p1 p2 lib
 
 (
   mkdir lib p1 p2
-  git init --bare lib
+  git init lib
   git init p1
   git init p2
 )
 
 (
-  git clone lib lib.git
-  cd lib.git
+  cd lib
   touch readme
   git add readme
   git commit -m "Initial lib"
-  git push
+  git checkout -b temp #To push to lib later we must not have working copy on master branch.
 )
 
 (
@@ -55,7 +54,7 @@ rm -fr p1 p2 lib lib.git
 
 (
   cd p2
-  git subrepo pull --rebase lib -v
+  git subrepo pull lib
   echo "p2 initial add to subrepo" >> lib/readme
   git add lib/readme
   git commit -m "p2 initial add to subrepo"
@@ -64,5 +63,5 @@ rm -fr p1 p2 lib lib.git
 
 (
   cd p1
-  git subrepo pull --all -v
+  git subrepo pull --all
 )


### PR DESCRIPTION
I solve this problem by finding a better _common-ancestor_ before merging. This _common-ancestor_ search is necessary as otherwise the _git merge_ command using the $subrepo_parent obtained from the .gitrepo file as the _common-ancestor_ would fail.  I believe this is because the merge command internally calls `git-merge-base`, which isn't sophisticated enough to find the best _common-ancestor_ in this context (due to one branch having the .gitrepo file and the other not).  We must do this search manually by comparing the trees without the presence of the .gitrepo file.

Previously I had solved the problem by **_caching**_ when the latest _git subrepo push_ command was, and used that point as the _common-ancestor_ during the merge (in the _git subrepo pull_ command).
- But that solution wasn't acceptable as the cache only stayed in the local repo- causing problems for other developers as they wouldn't recieve this cache.

Now I have solved the problem by **_searching**_ for where the lastest _git subrepo push_ command was done, and using that point as the _common-ancestor_ during the merge (in the _git subrepo pull_ command).
- This logic was placed into the get-best-common-ancestor-for-merge() function.
- This search has **M*N** complexity (two loops).
  - **M** (outer loop) is # of commits since last subrepo clone/pull in **_subrepo branch**_.
    - Essentially iterates over the output of `git rev-list subrepo/$subdir --format="format:%T"`, and stopping once the tree pertaining to the last subrepo clone/pull command is reached.
    - A further optimization here would be to call `git rev-list subrepo/$subdir --format="format:%T"` with the --after= argument, where the date is the date of the last _subrepo clone/pull_ commit. This might speed up the `git rev-list` command a bit with a large repo.
  - **N** (inner loop) is # of commits since last subrepo clone/pull in **_original branch**_.
    - Iterates over `git rev-list "$subrepo_parent".."$original_head_branch" -- "$subdir"`, which is the list of commits which modified the subrepo since the last subrepo clone/pull.
    - A further optimization within this loop can be made by caching the output of `git mktree < <(git ls-tree "$i:$subdir" | sed -r '/^.*\.gitrepo.*$/d')`.  This command is how we look at the tree without the .gitrepo file, so that we can quickly figure out where the best _common-ancestor_ is.
- This commit introduces process substitution (`cmd1 < <(cmd2)`) which introduces portablity concerns: http://wiki.bash-hackers.org/syntax/expansion/proc_subst#bugs_and_portability_considerations

**lib/git-subrepo command:pull() changes:**
- When pruning the merge history after the merge in command:pull(), it turns out in some flows I made that HEAD^2 doesn't always exist, so I threw HEAD there as a backup.
- Wrote get-best-common-ancestor-for-merge which solves my test case without caching subrepo-push commands! It does this by searching for when the last subrepo push was made, then using that as the common-ancestor so that the merge on a subrepo-pull will work. Importantly my technique doesn't use the I/O expensive git-filter-branch in its search.
- Modified the outer loop so that it would iterate over `git rev-list subrepo/$subdir --format="format:%T"` instead of following the first-parent-lineage from subrepo/$subdir.  Not convinced this is perfect, but is a good start at least.  Might need to use the output of the above rev-list command, then somehow follow each ancestor-branch with matching $outer_loop_term_tree entries.

**lib/git-subrepo command:push() changes:**
- In the event of a subrepo-push, then an external push to the subrepo from someone else, then a subrepo-pull, the history rewrite would disconnect HEAD^ from all ancestry.  This commit includes a test for that case, by checking (after the merge in the subrepo-pull) if HEAD^ is equal to HEAD^2^, and not rewriting the history in that case. I am certain an improvement can be done here though, as the resulting `git subrepo pull` commit is different than normal and is quite messy.
- Made rebase in subrepo-push verbose; will be useful if user has to fix things by hand.
- In subrepo-push the initial rebase onto upstream written by ingy won't always work, but will work if we rebase A..$checkout_branch onto $upstream_head where A is the last clone/merge log entry. I think this `rebase --onto` will work in all cases so should replace the simpler rebase, rather than just running if the simpler rebase failed.

**test/failing/test.sh changes:**
- Cleaned up this failing test case I gave ingy by making it simpler; didn't need the bare lib repository.
