### PR TITLE
PR/26

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -244,7 +244,7 @@ command:push() {
   subrepo-checkout
 
   # Attempt to rebase changes onto upstream:
-  FAIL=false RUN git rebase -v "$upstream_head" "$checkout_branch"
+  FAIL=false RUN git rebase "$upstream_head" "$checkout_branch"
 
   if ! OK; then
     # Let's rebase a bit more intelligently by using the log to see when the last clone/merge was.
@@ -252,7 +252,7 @@ command:push() {
     RUN git rebase --abort #Abort prior failed rebase.
     get-last-subrepo-merge-log-entry
     if [ -n "$output" ]; then
-      FAIL=false RUN git rebase -v --onto "$upstream_head" "$output" "$checkout_branch"
+      FAIL=false RUN git rebase --onto "$upstream_head" "$output" "$checkout_branch"
     else
       say "Unable to rebase changes from local branch onto subrepo origin as git log entry of last $subdir clone/merge wasn't found."
       OK=false
@@ -905,7 +905,7 @@ get-best-common-ancestor-for-merge() {
   outer_loop_term_tree="$output"
 
   # These are the outer loop elements, the tree of each commit in the subrepo branch:
-  OUT=true RUN sed '/commit/d' < <(git rev-list subrepo/$subdir --format="format:%T")
+  OUT=true RUN sed '/commit/d' < <(git rev-list subrepo/remote/$subdir --format="format:%T")
   local outer_loop_elems="$output"
 
   # These are the inner loop elements, cached here so they're only looked up once.


### PR DESCRIPTION
Fixes 2 problems introduced in PR/25.

(1) command:pull can look at the **subrepo/$subdir** branch, which had been removed as it wasn't needed. It should have been looking at **subrepo/remote/$subdir** which had been fetched earlier by `fetch-subrepo`.

(2) In command:push, when GIT_SUBREPO_VERBOSE=true the `rebase -v` commands print:
```
fatal: ambiguous argument '': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

However the command succeeds anyway. Here is an example of the full output:
```
>>> git rebase -v --onto 0dd3e4e0c5c0a2890f9717a2c42e4e11fefb37db 1f312a6bd7a27f27959f04da8d6296a69452d34d subrepo/lib
fatal: ambiguous argument '': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
Changes from  to 0dd3e4e0c5c0a2890f9717a2c42e4e11fefb37db:
First, rewinding head to replay your work on top of it...
Applying: p2 initial add to subrepo
```

I believe that has something to do with the porcelain command trying things during its fallback behaviour: http://stackoverflow.com/a/20967194/1185900

This patch removes that verbosity -v argument from the git rebase commands so that the misleading 'fatal' message is not printed.