### PR TITLE
Allows subrepo clone to clone to an empty branch; fixes #26.

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -592,7 +592,17 @@ subrepo:commit() {
   GIT_WORK_TREE="$subdir" RUN git reset --hard "$subrepo_commit_ref"
 
   o "Reset index to original commit"
-  RUN git reset --mixed "$original_head_commit"
+  if [[ -n "$original_head_commit" ]]; then
+    RUN git reset --mixed "$original_head_commit"
+  else
+    RUN git reset --mixed
+    # index currently considers $subdir content as deleted.
+    # Delete the index
+    local indexfile="$GIT_INDEX_FILE"
+    [[ -n "$indexfile" ]] ||
+      indexfile="$(git rev-parse --git-dir)/index"
+    RUN rm "$indexfile"
+  fi
 
   o "Put info into '$subdir/.gitrepo' file."
   update-gitrepo-file
@@ -893,8 +903,11 @@ assert-repo-is-ready() {
   # Get the original branch and commit:
   git:get-head-branch-name
   original_head_branch="$output"
-  git:get-head-branch-commit
-  original_head_commit="$output"
+
+  if [[ `git rev-parse -q --verify HEAD` ]]; then
+    git:get-head-branch-commit
+    original_head_commit="$output"
+  fi
 
   # If a subrepo branch is currently checked out, then note it:
   if [[ "$original_head_branch" =~ ^subrepo/(.*) ]]; then
@@ -911,17 +924,25 @@ assert-repo-is-ready() {
     error "Can't 'subrepo $command' outside a working tree."
 
   # HEAD exists:
-  RUN git rev-parse --verify HEAD
+  [[ "$command" == "clone" ]] ||
+    RUN git rev-parse --verify HEAD
 
   # Repo is in a clean state:
   if [[ "$command" =~ ^(clone|pull|push)$ ]]; then
     git update-index -q --ignore-submodules --refresh
     git diff-files --quiet --ignore-submodules ||
       error "Can't $command subrepo. Unstaged changes."
-    git diff-index --quiet --ignore-submodules HEAD ||
-      error "Can't $command subrepo. Working tree has changes."
-    git diff-index --quiet --cached --ignore-submodules HEAD ||
-      error "Can't $command subrepo. Index has changes."
+    if [[ ! "$command" == "clone" || `git rev-parse -q --verify HEAD` ]]; then
+      git diff-index --quiet --ignore-submodules HEAD ||
+        error "Can't $command subrepo. Working tree has changes."
+      git diff-index --quiet --cached --ignore-submodules HEAD ||
+        error "Can't $command subrepo. Index has changes."
+    else
+      # Repo has no commits and we're cloning a subrepo. Working tree won't
+      #  possibly have changes as there was nothing initial to change.
+      [[ -z $(git diff --cached) ]] ||
+        error "Can't $command subrepo. Index has changes."
+    fi
   fi
 
   # For now, only support actions from top of repo:
@@ -1123,7 +1144,7 @@ git:ref-exists() {
 
 git:get-head-branch-name() {
   output=
-  local name="$(git rev-parse --abbrev-ref HEAD)"
+  local name="$(git symbolic-ref --short --quiet HEAD)"
   [ "$name" == HEAD ] && return
   output="$name"
 }

--- a/test/issue26.t
+++ b/test/issue26.t
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -e
+
+source test/setup
+
+use Test::More
+
+clone-foo-and-bar
+
+(
+  mkdir -p "$OWNER/empty"
+  git init "$OWNER/empty"
+)
+
+# Test that the repo looks ok:
+{
+  test-exists \
+    "$OWNER/empty/.git/"
+}
+
+# Do the subrepo clone and test the output:
+{
+  clone_output="$(
+    cd $OWNER/empty
+    git subrepo clone ../../../$UPSTREAM/bar
+  )"
+
+  # Check output is correct:
+  is "$clone_output" \
+    "Subrepo '../../../tmp/upstream/bar' (master) cloned into 'bar'" \
+    'subrepo clone command output is correct'
+}
+
+# Check that subrepo files look ok:
+gitrepo=$OWNER/empty/bar/.gitrepo
+{
+  test-exists \
+    "$OWNER/empty/bar/" \
+    "$OWNER/empty/bar/Bar" \
+    "$gitrepo"
+}
+
+# Make sure status is clean:
+{
+  git_status="$(
+    cd $OWNER/empty
+    git status -s
+  )"
+
+  is "$git_status" \
+    "" \
+    'status is clean'
+}
+
+done_testing 6
+
+#teardown


### PR DESCRIPTION
Changes:
* lib/git-subrepo:
 * subrepo:commit:
    * Must reset differently if $original_head_commit doesn't exist.
    * Index considers $subdir context as deleted, so I delete the index (not sure if there is a better way).
    * Respects the $GIT_INDEX_FILE environmental variable if defined.
 * assert-repo-is-ready:
    * Must not test based off of last commit if no last commit exists.
    * Tests detecting if working tree or index has changes must be different:
    * Working tree couldn't possibly have changes if there was nothing there to begin with.
    * `git diff --cached` non-empty output detects if index has changes.
  * git:get-head-branch-name:
    * Now gets branch name when branch is empty.
* test/issue26.t:
  * Added a test for the subrepo clone into empty repo feature.

Bugs:
* It appears cloned subrepo's history will precede commit in branch; this should probably be removed in the future. e.g. if subrepo has commits A-B, after clone the initially empty branch will have commits A-B-C, where C is the auto-generated `git subrepo clone` commit. I believe This is a side effect of using different `git reset --mixed` call.