### PR TITLE
Fixes issue #51, where push prints misleading message.

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -448,6 +448,9 @@ subrepo:push() {
     fi
     o "Create subrepo branch '$branch':"
     CALL subrepo:branch "$branch"
+    if ! OK; then
+      error "There is nothing new to push."
+    fi
     o "Fetch the upstream: $subrepo_remote ($subrepo_branch):"
     CALL subrepo:fetch
     o "git rebase $refs_subrepo_upstream $branch"

--- a/test/error.t
+++ b/test/error.t
@@ -26,6 +26,20 @@ clone-foo-and-bar
   )
 }
 
+# Push when there is nothing to push, and verify push was ignored:
+{
+  is "$(
+    cd $OWNER/bar
+    catch git subrepo push foo
+  )" \
+    "git-subrepo: There is nothing new to push." \
+    "Error OK: check that 'push' requires changes to push"
+  (
+    cd $OWNER/bar
+    git subrepo --quiet clean foo
+  )
+}
+
 {
   like "$(catch git subrepo clone --foo)" \
     "error: unknown option \`foo" \
@@ -193,6 +207,6 @@ clone-foo-and-bar
     "Error OK: clone non-repo"
 }
 
-done_testing 29
+done_testing 30
 
 teardown


### PR DESCRIPTION
Changes:
* lib/git-subrepo
 * subrepo:push
    * Added error message if subrepo:branch call fails.
    * subrepo:branch is where detection of changes occurs, OK=false if it detected no changes occured.
* test/error.t
 * Added test for this new error message.