### PR TITLE
Allows subrepo clone to clone to an empty branch; fixes #26.

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -552,7 +552,17 @@ subrepo:commit() {
   GIT_WORK_TREE="$subdir" RUN git reset --hard "$subrepo_commit_ref"
 
   o "Reset index to original commit"
-  RUN git reset --mixed "$original_head_commit"
+  if [[ -n "$original_head_commit" ]]; then
+    RUN git reset --mixed "$original_head_commit"
+  else
+    RUN git reset --mixed
+    # index currently considers $subdir content as deleted at root.
+    # Delete the index
+    local indexfile="$GIT_INDEX_FILE"
+    [[ -n "$indexfile" ]] ||
+      indexfile="$(git rev-parse --git-dir)/index"
+    RUN rm "$indexfile"
+  fi
 
   o "Put info into '$subdir/.gitrepo' file."
   update-gitrepo-file
@@ -561,7 +571,16 @@ subrepo:commit() {
   RUN git add -A "$subdir"
 
   o "Commit to the '$original_head_branch' branch."
-  RUN git commit -m "$(get-commit-message)"
+  if [[ -n "$original_head_commit" ]]; then
+    RUN git commit -m "$(get-commit-message)"
+  else
+    # We had cloned into an empty repo, side effect of prior git reset --mixed
+    #  command is that subrepo's history is now part of the index. Commit
+    #  without that history.
+    OUT=true RUN git write-tree
+    OUT=true RUN git commit-tree -m "$(get-commit-message)" "$output"
+    RUN git reset --hard "$output"
+  fi
 
   o "Create ref '$refs_subrepo_commit'."
   git:make-ref "$refs_subrepo_commit" "$subrepo_commit_ref"
@@ -947,8 +966,11 @@ assert-repo-is-ready() {
   # Get the original branch and commit:
   git:get-head-branch-name
   original_head_branch="$output"
-  git:get-head-branch-commit
-  original_head_commit="$output"
+
+  if [[ `git rev-parse -q --verify HEAD` ]]; then
+    git:get-head-branch-commit
+    original_head_commit="$output"
+  fi
 
   # If a subrepo branch is currently checked out, then note it:
   if [[ "$original_head_branch" =~ ^subrepo/(.*) ]]; then
@@ -965,17 +987,25 @@ assert-repo-is-ready() {
     error "Can't 'subrepo $command' outside a working tree."
 
   # HEAD exists:
-  RUN git rev-parse --verify HEAD
+  [[ "$command" == "clone" ]] ||
+    RUN git rev-parse --verify HEAD
 
   # Repo is in a clean state:
   if [[ "$command" =~ ^(clone|pull|push|branch|commit)$ ]]; then
     git update-index -q --ignore-submodules --refresh
     git diff-files --quiet --ignore-submodules ||
       error "Can't $command subrepo. Unstaged changes."
-    git diff-index --quiet --ignore-submodules HEAD ||
-      error "Can't $command subrepo. Working tree has changes."
-    git diff-index --quiet --cached --ignore-submodules HEAD ||
-      error "Can't $command subrepo. Index has changes."
+    if [[ ! "$command" == "clone" || `git rev-parse -q --verify HEAD` ]]; then
+      git diff-index --quiet --ignore-submodules HEAD ||
+        error "Can't $command subrepo. Working tree has changes."
+      git diff-index --quiet --cached --ignore-submodules HEAD ||
+        error "Can't $command subrepo. Index has changes."
+    else
+      # Repo has no commits and we're cloning a subrepo. Working tree won't
+      #  possibly have changes as there was nothing initial to change.
+      [[ -z $(git ls-files) ]] ||
+        error "Can't $command subrepo. Index has changes."
+    fi
   fi
 
   # For now, only support actions from top of repo:
@@ -1182,7 +1212,7 @@ git:ref-exists() {
 
 git:get-head-branch-name() {
   output=
-  local name="$(git rev-parse --abbrev-ref HEAD)"
+  local name="$(git symbolic-ref --short --quiet HEAD)"
   [ "$name" == HEAD ] && return
   output="$name"
 }

--- a/test/subrepo-clone.t
+++ b/test/subrepo-clone.t
@@ -8,6 +8,11 @@ use Test::More
 
 clone-foo-and-bar
 
+(
+  mkdir -p "$OWNER/empty"
+  git init "$OWNER/empty"
+)
+
 # Test that the repos look ok:
 {
   test-exists \
@@ -15,7 +20,8 @@ clone-foo-and-bar
     "$OWNER/foo/Foo" \
     "!$OWNER/foo/bar/" \
     "$OWNER/bar/.git/" \
-    "$OWNER/bar/Bar"
+    "$OWNER/bar/Bar" \
+    "$OWNER/empty/.git/"
 }
 
 # Do the subrepo clone and test the output:
@@ -29,6 +35,16 @@ clone-foo-and-bar
   is "$clone_output" \
     "Subrepo '../../../tmp/upstream/bar' (master) cloned into 'bar'." \
     'subrepo clone command output is correct'
+
+  clone_output_empty="$(
+    cd $OWNER/empty
+    git subrepo clone ../../../$UPSTREAM/bar
+  )"
+
+  # Check output is correct:
+  is "$clone_output_empty" \
+    "Subrepo '../../../tmp/upstream/bar' (master) cloned into 'bar'." \
+    'subrepo clone command output is correct'
 }
 
 # Check that subrepo files look ok:
@@ -37,7 +53,10 @@ gitrepo=$OWNER/foo/bar/.gitrepo
   test-exists \
     "$OWNER/foo/bar/" \
     "$OWNER/foo/bar/Bar" \
-    "$gitrepo"
+    "$gitrepo" \
+    "$OWNER/empty/bar/" \
+    "$OWNER/empty/bar/Bar" \
+    "$OWNER/empty/bar/.gitrepo"
 }
 
 # Test foo/bar/.gitrepo file contents:
@@ -89,8 +108,17 @@ gitrepo=$OWNER/foo/bar/.gitrepo
   is "$git_status" \
     "" \
     'status is clean'
+
+  git_status_empty="$(
+    cd $OWNER/empty
+    git status -s
+  )"
+
+  is "$git_status_empty" \
+    "" \
+    'status is clean'
 }
 
-done_testing 16
+done_testing 22
 
 teardown


### PR DESCRIPTION
Changes:
* lib/git-subrepo:
  * subrepo:commit:
    * Must reset differently if $original_head_commit doesn't exist.
    * Index considers $subdir context as deleted, so I delete the index (not sure if there is a better way).
    * Respects the $GIT_INDEX_FILE environmental variable if defined.
    * **Creates a commit object without a parent as otherwise subrepo's history would be made the containing repo's history.**
  * assert-repo-is-ready:
    * Must not test based off of last commit if no last commit exists.
    * Tests detecting if working tree or index has changes must be different:
    * Working tree couldn't possibly have changes if there was nothing there to begin with.
    * **`git ls-files` non-empty output indicates index has changes.**
  * git:get-head-branch-name:
    * Now gets branch name when branch is empty.
* **test/subrepo-clone.t**:
  * Added testing for the subrepo clone into empty repo feature.

**Known Bugs:**
* Bug occurs on later pull after subrepo clone into empty repo. Bug is due to triggered subrepo.former check, as subrepo.parent is empty.
  * subrepo.parent is empty as the subrepo clone had no parent commit.
  * As soon as that deprecated subrepo.former check is removed this bug should be fixed.