### PR TITLE
Prevents subrepo:commit from deleting untracked files in subrepo.

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -545,8 +545,15 @@ subrepo:commit() {
   o "Remove old content of the subdir."
   (
     cd "./$subdir"
-    RUN rm -fr $(ls -A)
+    RUN rm -f $(git ls-files)
   )
+
+  # "Ignore untracked files during work."
+  OUT=true RUN git rev-parse --git-dir
+  local git_dir="$output"
+  RUN cp "$git_dir/info/exclude" "$git_dir/info/exclude.bak"
+  OUT=true RUN git ls-files -o
+  echo "$output" >> "$git_dir/info/exclude"
 
   o "Put remote subrepo content into '$subdir/'."
   GIT_WORK_TREE="$subdir" RUN git reset --hard "$subrepo_commit_ref"
@@ -558,7 +565,10 @@ subrepo:commit() {
   update-gitrepo-file
 
   o "Add '$subdir/' content to the index."
-  RUN git add -A "$subdir"
+  RUN git add -A -- "$subdir"
+
+  # Reset exclude file.
+  RUN mv "$git_dir/info/exclude.bak" "$git_dir/info/exclude"
 
   o "Commit to the '$original_head_branch' branch."
   RUN git commit -m "$(get-commit-message)"

--- a/test/subrepo-push.t
+++ b/test/subrepo-push.t
@@ -22,6 +22,10 @@ clone-foo-and-bar
   modify-files bar/FooBar
   modify-files ./FooBar
   modify-files ./FooBar bar/FooBar
+
+  # Add untracked files:
+  touch bar/bart
+  touch bar/bard/bart
 ) &> /dev/null || die
 
 (
@@ -60,6 +64,8 @@ test-exists \
   "$OWNER/bar/bard/" \
   "$OWNER/bar/bargy" \
   "!$OWNER/bar/.gitrepo" \
+  "$OWNER/foo/bar/bart" \
+  "$OWNER/foo/bar/bard/bart" \
 
 # assert-original-state "$OWNER/foo" "bar"
 


### PR DESCRIPTION
Changes:
* lib/git-subrepo:
  * subrepo:commit:
    * Removes only tracked files in $subdir.
    * Ensures untracked files are not deleted or added to index.
    * Algorithm is to ignore untracked files:
      * Determine what is untracked (via git ls-files -o),
      * Add those to an ignore file via `$GIT_DIR/info/excludes` (alternatively could be via `core.excludesfile`),
      * Add everything as before with git add -A -- "$subdir",
      * Revert the ignore file.
    * Alternative algorithm would be to:
      * Record tracked files in two places (before/after `git reset --mixed`), only the union of the two works.
      * Must explicitly add .gitrepo as during initial clone it isn't tracked.
* test/subrepo-push.t
  * Adds a couple untracked files, and verifies that they exist after a pull/push.