### PR TITLE
issues 91, 95 and 96

### DIFF
--- a/Intro.pod
+++ b/Intro.pod
@@ -395,9 +395,9 @@ The pull command does these steps:
 
 =item * Create a branch of local subrepo commits since last pull
 
-=item * Rebase this branch onto the upstream commits
+=item * Squashes local changes into one commit and cherry-picks it onto upstream
 
-=item * Commit the HEAD of the rebased content
+=item * Commit the HEAD of the upstream branch with local changes on top of it
 
 =item * Update/amend the .gitrepo file
 
@@ -456,7 +456,7 @@ This was from a minimal case. Subtree history (when viewed this way at least)
 gets unreasonably ugly fast. Subrepo history, by contrast, always looks as
 clean as shown.
 
-The final command, push, bascially just does the pull/rebase dance above
+The final command, push, bascially just does the pull/cherry-pick dance above
 described, and pushes the resulting history back. It does not squash the
 commits made locally, because it assumed that when you changed the local
 subrepo, you made messages that were intended to eventually be published

--- a/ReadMe.pod
+++ b/ReadMe.pod
@@ -174,13 +174,14 @@ The C<pull> command will attempt to do the following commands in one go:
 
     git subrepo fetch <subdir>
     git subrepo branch <subdir>
-    git rebase subrepo/<subdir>/upstream subrepo/<subdir>
+    git checkout subrepo/<subdir>/upstream
+    git cherry-pick subrepo/<subdir>
     git checkout ORIG_HEAD
     git subrepo commit <subdir>
 
 In other words, you could do all the above commands yourself, for the same
 effect. If any of the commands fail, subrepo will stop and tell you to finish
-this by hand. Generally a failure would be in the rebase, where conflicts can
+this by hand. Generally a failure would be in the cherry-pick, where conflicts can
 happen. Since Git has lots of ways to resolve conflicts to your personal
 tastes, the subrepo command defers to letting you do this by hand.
 
@@ -253,7 +254,7 @@ The C<branch> command accepts the C<--all> and C<--force> options.
 Add subrepo branch to current history as a single commit.
 
 This command is generally used after a hand-merge. You have done a C<subrepo
-branch> and merged (rebased) it with the upstream. This command takes the HEAD
+branch> and cherry-picked the changes to the upstream. This command takes the HEAD
 of that branch, puts its content into the subrepo subdir and adds a new commit
 for it to the top of your mainline history.
 

--- a/doc/git-subrepo.swim
+++ b/doc/git-subrepo.swim
@@ -135,13 +135,14 @@ the same arguments. Keep reading…
 
     git subrepo fetch <subdir>
     git subrepo branch <subdir>
-    git rebase subrepo/<subdir>/upstream subrepo/<subdir>
+    git checkout subrepo/<subdir>/upstream
+    git cherry-pick subrepo/<subdir>
     git checkout ORIG_HEAD
     git subrepo commit <subdir>
 
   In other words, you could do all the above commands yourself, for the same
   effect. If any of the commands fail, subrepo will stop and tell you to
-  finish this by hand. Generally a failure would be in the rebase, where
+  finish this by hand. Generally a failure would be in the cherry-pick, where
   conflicts can happen. Since Git has lots of ways to resolve conflicts to
   your personal tastes, the subrepo command defers to letting you do this by
   hand.
@@ -214,8 +215,8 @@ the same arguments. Keep reading…
 
   Add subrepo branch to current history as a single commit.
 
-  This command is generally used after a hand-merge. You have done a `subrepo
-  branch` and merged (rebased) it with the upstream. This command takes the
+  This command is generally used after a hand-made cherry-picking. You have done a `subrepo
+  branch` and cherry-picked the changes to the upstream. This command takes the
   HEAD of that branch, puts its content into the subrepo subdir and adds a new
   commit for it to the top of your mainline history.
 

--- a/doc/intro-to-subrepo.swim
+++ b/doc/intro-to-subrepo.swim
@@ -292,8 +292,8 @@ The pull command does these steps:
 * Fetch the upstream content
 * Check if anything needs pulling
 * Create a branch of local subrepo commits since last pull
-* Rebase this branch onto the upstream commits
-* Commit the HEAD of the rebased content
+* Squashes all local commits into one and cherry-picks the results onto upstream HEAD
+* Commit the HEAD of the branch with a cherry-pick
 * Update/amend the .gitrepo file
 
 === Clean History
@@ -349,7 +349,7 @@ This was from a minimal case. Subtree history (when viewed this way at least)
 gets unreasonably ugly fast. Subrepo history, by contrast, always looks as
 clean as shown.
 
-The final command, push, bascially just does the pull/rebase dance above
+The final command, push, bascially just does the pull/cherry-pick dance above
 described, and pushes the resulting history back. It does not squash the
 commits made locally, because it assumed that when you changed the local
 subrepo, you made messages that were intended to eventually be published back

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -505,7 +505,17 @@ subrepo:push() {
         --parent-filter "sed 's/^$/-p $subrepo_commit/'" \
         -- "$branch_name"
 
+      # If there were several pulls before this push, the squashed commit will contain changes
+      # but won't be cherry-picked to upstream as all the changes are already present there.
+      # To prevent a failure here we additionally check that this commit does contain real changes.
       local commit="$(git rev-parse "$branch_name")"
+      o "Check if cherry-pick contains non-processed changes"
+      FAIL=false RUN git diff --quiet "$commit" "$refs_subrepo_fetch"
+      if OK; then
+        o "Cherry-pick commit contains no changes, push aborted"
+        OK=false; CODE=-2; return
+      fi
+
       o "Cherry-pick the squashed changes from $commit to $upstream_ref"
       RUN git checkout "$branch_name"
       RUN git reset --hard "$refs_subrepo_fetch"

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -484,6 +484,8 @@ subrepo:push() {
         RUN git push \
           "$subrepo_remote" "$subrepo_commit:refs/heads/$subrepo_branch"
         new_upstream=true
+        upstream_head_commit=$(git rev-parse "$subrepo_commit")
+        o "Upstream head commit set to $upstream_head_commit"
       else
         error "Fetch for push failed: $output"
       fi

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -641,14 +641,23 @@ subrepo:branch() {
   FAIL=false RUN git branch -D "$cherry_branch"
   RUN git branch "$cherry_branch"
 
-  o "Prepare the commit message for a squashed cherry-pick commit"
-  local commit_message="git-subrepo cherry-pick of the following commits:"$'\n\n'
-  commit_message+="$(git log "$cherry_branch" --first-parent)"
+  #if there are local changes, squash them and apply onto subrepo upstream
+  FAIL=false RUN git diff --quiet "$prev_pull_commit" "$cherry_branch"
+  if OK; then
+    o "No local changes found"
+    # Reset to the branch where we started:
+    RUN git reset --hard "$original_head_commit"
+    OK=false; CODE=-2; return
+  else
+    o "Prepare the commit message for a squashed cherry-pick commit"
+    local commit_message="git-subrepo cherry-pick of the following commits:"$'\n\n'
+    commit_message+="$(git log "$cherry_branch" --first-parent)"
 
-  o "Squash all changes since the last pull into one commit"
-  RUN git reset --hard "$prev_pull_commit"
-  RUN git merge --squash "$cherry_branch"
-  RUN git commit -m "$commit_message"
+    o "Squash all changes since the last pull into one commit"
+    RUN git reset --hard "$prev_pull_commit"
+    RUN git merge --squash "$cherry_branch"
+    RUN git commit -m "$commit_message"
+  fi
 
   o "Create branch '$branch' for this new commit set."
   RUN git branch "$branch"
@@ -677,7 +686,7 @@ subrepo:commit() {
 
   o "Remove old content of the subdir."
   (
-    cd "./$subdir"
+    cd "./$subdir" || die
     RUN rm -fr $(ls -A)
   )
 

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -87,8 +87,10 @@ main() {
   local subrepo_remote=         # Remote url for subrepo's upstream repo
   local subrepo_branch=         # Upstream branch to clone/push/pull
   local subrepo_commit=         # Upstream HEAD from previous clone/pull
-  local subrepo_parent=         # Local commit from before previous clone/pull
-  local subrepo_former=         # A retired gitrepo key that might still exist
+
+  local subrepo_pull_parent=    # Parent of a local commit created during the previous subrepo pull
+  local subrepo_push_parent=    # Parent of a local commit created during the previous subrepo push
+  local subrepo_current_parent= # Either subrepo_pull_parent or subrepo_push_parent, depending on current operation
 
   local refs_subrepo_branch=    # A subrepo ref -> commit of branch command
   local refs_subrepo_commit=    # A subrepo ref -> commit last merged
@@ -193,7 +195,7 @@ command:pull() {
   elif [[ "$CODE" -eq -1 ]]; then
     say "Subrepo '$subdir' is up to date."
   elif [[ "$CODE" -eq 1 ]]; then
-    error-pull-rebase
+    error-pull-cherry-pick
     return "$CODE"
   else
     die "Unknown pull error code: '$CODE'"
@@ -211,7 +213,7 @@ command:push() {
   elif [[ "$CODE" -eq -2 ]]; then
     say "Subrepo '$subdir' has no new commits to push."
   elif [[ "$CODE" -eq 2 ]]; then
-    error-push-rebase
+    error-push-cherry-pick
     return "$CODE"
   else
     die "Unknown push error code: '$CODE'"
@@ -244,6 +246,7 @@ command:branch() {
   fi
 
   # Create the subrepo branch:
+  subrepo_current_parent="$subrepo_pull_parent"
   subrepo:branch
   if ! OK; then
     say "Can't create branch '$branch'. No new commits since last pull/clone."
@@ -436,12 +439,16 @@ subrepo:pull() {
     RUN git branch -D "$branch_name"
   fi
   o "Create subrepo branch '$branch_name':"
+  subrepo_current_parent="$subrepo_pull_parent"
   CALL subrepo:branch
   if OK; then
-    o "git rebase $upstream_ref $branch_name"
-    FAIL=false OUT=true RUN git rebase "$refs_subrepo_fetch" "$branch_name"
+    local commit="$(git rev-parse "$branch_name")"
+    o "Cherry-pick the squashed changes from $commit to $upstream_ref"
+    RUN git checkout "$branch_name"
+    RUN git reset --hard "$refs_subrepo_fetch"
+    FAIL=false OUT=true RUN git cherry-pick "$commit"
     if ! OK; then
-      o "The rebase command failed:"$'\n'----$'\n'"$output"$'\n'----
+      o "Cherry-picking failed"$'\n'----$'\n'"$output"$'\n'----
       CODE=1; return
     fi
     o "Checkout '$original_head_branch'."
@@ -487,13 +494,22 @@ subrepo:push() {
       fi
 
       o "Create subrepo branch '$branch_name':"
+      subrepo_current_parent="$subrepo_push_parent"
       CALL subrepo:branch "$branch_name"
       if ! OK; then return; fi
 
-      o "git rebase $refs_subrepo_fetch $branch_name"
-      FAIL=false OUT=true RUN git rebase "$refs_subrepo_fetch" "$branch_name"
+      o "git filter-branch --force --parent-filter \"sed 's/^$/-p $subrepo_commit/'\" $branch_name"
+      FAIL=false RUN git filter-branch --force \
+        --parent-filter "sed 's/^$/-p $subrepo_commit/'" \
+        -- "$branch_name"
+
+      local commit="$(git rev-parse "$branch_name")"
+      o "Cherry-pick the squashed changes from $commit to $upstream_ref"
+      RUN git checkout "$branch_name"
+      RUN git reset --hard "$refs_subrepo_fetch"
+      FAIL=false OUT=true RUN git cherry-pick "$commit"
       if ! OK; then
-        o "The rebase command failed:"$'\n'----$'\n'"$output"$'\n'----
+        o "Cherry-picking command failed:"$'\n'----$'\n'"$output"$'\n'----
         CODE=2; return
       fi
       RUN git checkout "$original_head_branch"
@@ -566,7 +582,7 @@ subrepo:fetch() {
   git:make-ref "$refs_subrepo_fetch" FETCH_HEAD
 }
 
-# Create a subrepo branch of changes since last pull:
+# Create a subrepo branch of changes since last pull or push:
 subrepo:branch() {
   local branch="${1:-"subrepo/$subdir"}"
   o "Check if the '$branch' branch already exists."
@@ -574,21 +590,25 @@ subrepo:branch() {
 
   o "Make sure there is at least one commit after the last pull."
   # (That translates to 2 commits after the parent of last pull):
-  local count="$(git rev-list "$subrepo_parent"..HEAD -2 | grep -c $'\n')"
+  local count="$(git rev-list "$subrepo_current_parent"..HEAD -2 | grep -c $'\n')"
   if [ "$count" != 2 ]; then
     OK=false; CODE=-2; return
   fi
 
   o "Remove the commits before last pull."
   FAIL=false RUN git filter-branch --force \
-    --parent-filter "grep -v $subrepo_parent || true" \
-    -- "$subrepo_parent"..HEAD
+    --parent-filter "grep -v $subrepo_current_parent || true" \
+    -- "$subrepo_current_parent"..HEAD
 
   # Note: We need to have the last pull commit or this next step can fail.
   o "Get commits specific to the subdir."
   FAIL=false RUN git filter-branch -f \
     --subdirectory-filter "$subdir" \
     HEAD
+
+  o "Remove the .gitrepo file from the history."
+  RUN git filter-branch -f \
+    --tree-filter "rm -f .gitrepo" --prune-empty
 
   o "Make sure there are *subrepo* commits after the last pull."
   local count="$(git rev-list HEAD -2 | grep -c $'\n')"
@@ -599,26 +619,33 @@ subrepo:branch() {
     return
   fi
 
-  # Now we can get rid of the previous pull commit.
-  # First get the final commit, which is the last pull one:
-  local prev_pull_commit="$(git rev-list HEAD | tail -1)"
+  o "Find the previous pull commit to use as a base revision for the local changes"
+  local prev_pull_commit="$(git rev-list --first-parent HEAD | tail -1)"
   [ -n "$prev_pull_commit" ] ||
     die "Can't find previous clone/pull commit."
 
-  o "Remove the previous pull commit."
-  FAIL=false RUN git filter-branch --force \
-    --parent-filter "grep -v $prev_pull_commit || true" \
-    -- "$prev_pull_commit"..HEAD
+  o "Create temporary branch subrepo-cherry/$subdir to squash local changes"
+  local cherry_branch="subrepo-cherry/$subdir"
+  FAIL=false RUN git branch -D "$cherry_branch"
+  RUN git branch "$cherry_branch"
 
-  o "Remove the .gitrepo file from the history."
-  RUN git filter-branch -f \
-    --tree-filter "rm -f .gitrepo"
+  o "Prepare the commit message for a squashed cherry-pick commit"
+  local commit_message="git-subrepo cherry-pick of the following commits:"$'\n\n'
+  commit_message+="$(git log "$cherry_branch" --first-parent)"
+
+  o "Squash all changes since the last pull into one commit"
+  RUN git reset --hard "$prev_pull_commit"
+  RUN git merge --squash "$cherry_branch"
+  RUN git commit -m "$commit_message"
 
   o "Create branch '$branch' for this new commit set."
   RUN git branch "$branch"
 
   o "Reset to the '$original_head_branch' branch."
   RUN git reset --hard "$original_head_commit"
+
+  o "Remove temporary branch used for cherry-picking"
+  FAIL=false RUN git branch -D "$cherry_branch"
 }
 
 # Commit a merged subrepo branch:
@@ -736,13 +763,10 @@ subrepo:status() {
     echo "  Tracking Branch: $subrepo_branch"
     [ -z "$subrepo_commit" ] ||
       echo "  Pulled Commit:   $(git rev-parse --short $subrepo_commit)"
-    if [ -n "$subrepo_parent" ]; then
-      echo "  Pull Parent:     $(git rev-parse --short $subrepo_parent)"
-    # TODO Remove this eventually:
-    elif [ -n "$subrepo_former" ]; then
-      printf "  Former Commit:   $(git rev-parse --short $subrepo_former)"
-      echo " *** DEPRECATED ***"
-    fi
+    [ -n "$subrepo_pull_parent" ] &&
+      echo "  Pull Parent:     $(git rev-parse --short $subrepo_pull_parent)"
+    [ -n "$subrepo_push_parent" ] &&
+      echo "  Push Parent:     $(git rev-parse --short $subrepo_push_parent)"
 
     if "$verbose_wanted"; then
       status-refs
@@ -754,7 +778,7 @@ subrepo:status() {
 
 subrepo:clean() {
   # Remove subrepo branches if exist:
-  for prefix in subrepo subrepo-push; do
+  for prefix in subrepo subrepo-push subrepo-cherry; do
     local branch="$prefix/$subdir"
     local ref="refs/heads/$branch"
     if [ -e ".git/$ref" ]; then
@@ -994,13 +1018,12 @@ read-gitrepo-file() {
   subrepo_commit="$output"
 
   FAIL=false \
-  SAY=false OUT=true RUN git config --file="$gitrepo" subrepo.parent
-  subrepo_parent="$output"
+  SAY=false OUT=true RUN git config --file="$gitrepo" subrepo.pull.parent
+  subrepo_pull_parent="$output"
 
-  if [ -z "$subrepo_parent" ]; then
-    SAY=false OUT=true RUN git config --file="$gitrepo" subrepo.former
-    subrepo_former="$output"
-  fi
+  FAIL=false \
+  SAY=false OUT=true RUN git config --file="$gitrepo" subrepo.push.parent
+  subrepo_push_parent="$output"
 }
 
 # Update the subdir/.gitrepo state file:
@@ -1029,7 +1052,22 @@ update-gitrepo-file() {
   fi
 
   RUN git config --file="$gitrepo" subrepo.commit "$upstream_head_commit"
-  RUN git config --file="$gitrepo" subrepo.parent "$original_head_commit"
+
+  if [ -n "$subrepo_current_parent" ] && [[ "$subrepo_current_parent" == "subrepo_push_parent" ]]; then
+    o "Update .girepo parents after a push"
+    RUN git config --file="$gitrepo" subrepo.pull.parent "$original_head_commit"
+    RUN git config --file="$gitrepo" subrepo.push.parent "$original_head_commit"
+  elif [ -n "$subrepo_current_parent" ] && [[ "$subrepo_current_parent" == "$subrepo_pull_parent" ]]; then
+    o "Update .girepo parents after a pull"
+    RUN git config --file="$gitrepo" subrepo.pull.parent "$original_head_commit"
+    RUN git config --file="$gitrepo" subrepo.push.parent "$subrepo_push_parent"
+  else
+    o "Update .girepo parents after init/clone/commit"
+    RUN git config --file="$gitrepo" subrepo.pull.parent "$original_head_commit"
+    RUN git config --file="$gitrepo" subrepo.push.parent "$original_head_commit"
+  fi
+
+
   RUN git config --file="$gitrepo" subrepo.cmdver "$VERSION"
 }
 
@@ -1263,12 +1301,12 @@ get-command-info() {
 #------------------------------------------------------------------------------
 # Instructional errors:
 #------------------------------------------------------------------------------
-error-pull-rebase() {
+error-pull-cherry-pick() {
   cat <<...
-The 'git rebase' command failed during your pull.
+The 'git cherry-pick' command failed during your pull.
 You will need to finish the pull by hand. Follow these steps:
 
-  # Resolve the rebase conflicts
+  # Resolve the cherry-pick conflicts
   git checkout $original_head_branch
   git subrepo commit $subdir
 
@@ -1276,12 +1314,12 @@ You will need to finish the pull by hand. Follow these steps:
   error-reset-message pull
 }
 
-error-push-rebase() {
+error-push-cherry-pick() {
   cat <<...
-The 'git rebase' command failed during your push.
+The 'git cherry-pick' command failed during your push.
 You will need to finish the push by hand. Follow these steps:
 
-  # Resolve the rebase conflicts
+  # Resolve the cherry-pick conflicts
   git checkout $original_head_branch
   git subrepo push $subdir subrepo-push/$subdir
 
@@ -1293,7 +1331,7 @@ error-reset-message() {
   cat <<...
 To abort the $1 and reset back to where you started:
 
-  git rebase --abort
+  git cherry-pick --abort
   git checkout ORIG_HEAD
   git subrepo clean $subdir
 

--- a/man/man1/git-subrepo.1
+++ b/man/man1/git-subrepo.1
@@ -229,14 +229,15 @@ The \f(CW\*(C`pull\*(C'\fR command will attempt to do the following commands in 
 .Vb 5
 \&    git subrepo fetch <subdir>
 \&    git subrepo branch <subdir>
-\&    git rebase subrepo/<subdir>/upstream subrepo/<subdir>
+\&    git checkout subrepo/<subdir>/upstream
+\&    git cherry-pick subrepo/<subdir>
 \&    git checkout ORIG_HEAD
 \&    git subrepo commit <subdir>
 .Ve
 .Sp
 In other words, you could do all the above commands yourself, for the same
 effect. If any of the commands fail, subrepo will stop and tell you to finish
-this by hand. Generally a failure would be in the rebase, where conflicts can
+this by hand. Generally a failure would be in the cherry-pick, where conflicts can
 happen. Since Git has lots of ways to resolve conflicts to your personal
 tastes, the subrepo command defers to letting you do this by hand.
 .Sp
@@ -309,8 +310,8 @@ The \f(CW\*(C`branch\*(C'\fR command accepts the \f(CW\*(C`\-\-all\*(C'\fR and \
 .IX Item "git subrepo commit <subdir> [<subrepo-ref>]"
 Add subrepo branch to current history as a single commit.
 .Sp
-This command is generally used after a hand-merge. You have done a \f(CW\*(C`subrepo
-branch\*(C'\fR and merged (rebased) it with the upstream. This command takes the \s-1HEAD\s0
+This command is generally used after a hand-made cherry-picking. You have done a \f(CW\*(C`subrepo
+branch\*(C'\fR and cherry-picked the changes to the upstream. This command takes the \s-1HEAD\s0
 of that branch, puts its content into the subrepo subdir and adds a new commit
 for it to the top of your mainline history.
 .Sp

--- a/test/issue29.t
+++ b/test/issue29.t
@@ -82,7 +82,8 @@ msg_main2="main2 initial add to subrepo"
     # We have a rebase conflict. Resolve it:
     git checkout --theirs readme
     git add readme
-    git rebase --continue
+    export GIT_EDITOR=/usr/bin/true
+    git cherry-pick --continue
     git checkout master
   }
 
@@ -99,7 +100,7 @@ msg_main2="main2 initial add to subrepo"
     # bail out of the pull.
 
     # We have a rebase conflict. Resolve it:
-    git rebase --skip
+    git cherry-pick --abort
     git checkout master
     git subrepo commit share
   }

--- a/test/issue95.t
+++ b/test/issue95.t
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -e
+
+source test/setup
+
+use Test::More
+
+{
+    cd "$TMP"
+
+    # Make two new repos
+    (
+        mkdir host sub
+        git init host
+        git init sub
+    ) > /dev/null
+
+    # Initialize host repo
+    (
+        cd host
+        touch host
+        git add host
+        git commit -m "host initial commit"
+    ) > /dev/null
+
+    # Initialize sub repo
+    (
+        cd sub
+        git init
+        touch subrepo
+        git add subrepo
+        git commit -m "subrepo initial commit"
+    ) > /dev/null
+
+    # Make sub a subrepo of host
+    (
+        cd host
+        git subrepo clone ../sub sub
+    ) > /dev/null
+
+    # Create a branch in host and make some changes in it
+    (
+        cd host
+        git checkout -b feature
+        touch feature
+        git add feature
+        git commit -m "feature added"
+        git checkout master
+    ) &> /dev/null
+
+    # Commit directly to subrepo
+    (
+        cd sub
+        echo "direct change in sub" >> subrepo
+        git commit -a -m "direct change in sub"
+    ) > /dev/null
+
+    # pull subrepo changes
+    (
+        cd host
+        git subrepo pull sub
+    ) > /dev/null
+
+    # commit directly to subrepo
+    (
+        cd sub
+        echo "another direct change in sub" >> subrepo
+        git commit -a -m "another direct change in sub"
+    ) > /dev/null
+
+    # commit to host/sub
+    (
+        cd host
+        echo "change from host" >> sub/subrepo-host
+        git add sub/subrepo-host
+        git commit -m "change from host"
+    ) > /dev/null
+
+    # merge previously created feature branch
+    (
+        cd host
+        git merge --no-ff --no-edit feature
+    ) > /dev/null
+
+    # pull subrepo changes
+    # expected: successful pull without conflicts
+    (
+        is "$(
+            cd host
+            git subrepo pull sub
+        )" \
+        "Subrepo 'sub' pulled from '../sub' (master)."
+    )
+
+}
+
+done_testing 1
+
+teardown

--- a/test/issue96.t
+++ b/test/issue96.t
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -e
+
+source test/setup
+
+use Test::More
+
+{
+    cd "$TMP"
+
+    # Make two new repos
+    (
+        mkdir host sub
+        git init host
+        git init sub
+    ) > /dev/null
+
+    # Initialize host repo
+    (
+        cd host
+        touch host
+        git add host
+        git commit -m "host initial commit"
+    ) > /dev/null
+
+    # Initialize sub repo
+    (
+        cd sub
+        git init
+        touch subrepo
+        git add subrepo
+        git commit -m "subrepo initial commit"
+    ) > /dev/null
+
+    # Make sub a subrepo of host
+    (
+        cd host
+        git subrepo clone ../sub sub
+    ) > /dev/null
+
+    # Commit some changes to the host repo
+    (
+        cd host
+        touch feature
+        git add feature
+        git commit -m "feature added"
+    ) &> /dev/null
+
+    # Commit directly to subrepo
+    (
+        cd sub
+        echo "direct change in sub" >> subrepo
+        git commit -a -m "direct change in sub"
+    ) > /dev/null
+
+    # Pull subrepo changes
+    (
+        cd host
+        git subrepo pull sub
+    ) > /dev/null
+
+    # Commit directly to subrepo
+    (
+        cd sub
+        echo "another direct change in sub" >> subrepo
+        git commit -a -m "another direct change in sub"
+    ) > /dev/null
+
+    # Commit to host/sub
+    (
+        cd host
+        echo "change from host" >> sub/subrepo-host
+        git add sub/subrepo-host
+        git commit -m "change from host"
+    ) > /dev/null
+
+    # Pull subrepo changes
+    # expected: successful pull without conflicts
+    (
+        is "$(
+            cd host
+            git subrepo pull sub
+        )" \
+        "Subrepo 'sub' pulled from '../sub' (master)."
+    )
+
+}
+
+done_testing 1
+
+teardown

--- a/test/issue96.t
+++ b/test/issue96.t
@@ -6,7 +6,6 @@ source test/setup
 
 use Test::More
 
-{
     cd "$TMP"
 
     # Make two new repos
@@ -65,7 +64,8 @@ use Test::More
         cd sub
         echo "another direct change in sub" >> subrepo
         git commit -a -m "another direct change in sub"
-    ) > /dev/null
+        git checkout -b temp # otherwise push to master will fail
+    ) &> /dev/null
 
     # Commit to host/sub
     (
@@ -75,18 +75,24 @@ use Test::More
         git commit -m "change from host"
     ) > /dev/null
 
-    # Pull subrepo changes
-    # expected: successful pull without conflicts
     (
+        # Pull subrepo changes
+        # expected: successful pull without conflicts
         is "$(
             cd host
             git subrepo pull sub
         )" \
         "Subrepo 'sub' pulled from '../sub' (master)."
+
+        # Push subrepo changes
+        # expected: successful push without conflicts
+        is "$(
+            cd host
+            git subrepo push sub -b master -u
+        )" \
+        "Subrepo 'sub' pushed to '../sub' (master)."
     )
 
-}
-
-done_testing 1
+done_testing 2
 
 teardown

--- a/test/subrepo-clone.t
+++ b/test/subrepo-clone.t
@@ -67,7 +67,8 @@ gitrepo=$OWNER/foo/bar/.gitrepo
   test-gitrepo-field "remote" "../../../$UPSTREAM/bar"
   test-gitrepo-field "branch" "master"
   test-gitrepo-field "commit" "$bar_head_commit"
-  test-gitrepo-field "parent" "$foo_clone_commit"
+  test-gitrepo-field "pull.parent" "$foo_clone_commit"
+  test-gitrepo-field "push.parent" "$foo_clone_commit"
   test-gitrepo-field "cmdver" "`git subrepo --version`"
 }
 
@@ -119,6 +120,6 @@ gitrepo=$OWNER/foo/bar/.gitrepo
     'status is clean'
 }
 
-done_testing 22
+done_testing 23
 
 teardown

--- a/test/subrepo-init.t
+++ b/test/subrepo-init.t
@@ -39,7 +39,8 @@ is "$output" "Subrepo created from 'doc' (with no remote)." \
   test-gitrepo-comment-block
   test-gitrepo-field "remote" "none"
   test-gitrepo-field "branch" "master"
-  test-gitrepo-field "parent" "$init_clone_commit"
+  test-gitrepo-field "pull.parent" "$init_clone_commit"
+  test-gitrepo-field "push.parent" "$init_clone_commit"
   test-gitrepo-field "cmdver" "`git subrepo --version`"
 }
 

--- a/test/subrepo-pull.t
+++ b/test/subrepo-pull.t
@@ -39,12 +39,14 @@ gitrepo=$OWNER/foo/bar/.gitrepo
 # Test foo/bar/.gitrepo file contents:
 {
   foo_pull_commit="$(cd $OWNER/foo; git rev-parse HEAD^)"
+  foo_push_commit="$(cd $OWNER/foo; git rev-parse HEAD^^)"
   bar_head_commit="$(cd $OWNER/bar; git rev-parse HEAD)"
   test-gitrepo-comment-block
   test-gitrepo-field "remote" "../../../$UPSTREAM/bar"
   test-gitrepo-field "branch" "master"
   test-gitrepo-field "commit" "$bar_head_commit"
-  test-gitrepo-field "parent" "$foo_pull_commit"
+  test-gitrepo-field "pull.parent" "$foo_pull_commit"
+  test-gitrepo-field "push.parent" "$foo_push_commit"
   test-gitrepo-field "cmdver" "`git subrepo --version`"
 }
 


### PR DESCRIPTION
This pull requests fixes a severe issue reported in #91, #95 and #96. Instead of rebasing during pulls and pushes I suggest to squash all the local changes into one commit and cherry-pick it onto upstream subrepo repository contents. This seems to be much more robust solution than rebasing.

Here I also separate pointers for pull parent commit and push parent commit. To do this, I had to change `.gitrepo` format. This means that after merging this pull request git-subrepo will become incompatible with earlier version. To overcome this issue, I can write a migration script. It will check whether .gitrepo has the old format and update it to the new one. Let me know if this is an acceptable solution.