### PR TITLE
Adds a test-exists-in-index() test fuction, for use in test suite.

### DIFF
--- a/test/setup
+++ b/test/setup
@@ -85,6 +85,29 @@ test-exists() {
   done
 }
 
+test-exists-in-index() {
+  for f in $*; do
+    if [[ "$f" =~ ^! ]]; then
+      f="${f#!}"
+      if [[ "$f" =~ /$ ]]; then
+        ok "`[ ! $(git ls-tree --full-tree --name-only -r HEAD "$f") ]`" \
+          "Directory '$f' does not exist in index"
+      else
+        ok "`[ ! $(git ls-tree --full-tree --name-only -r HEAD "$f") ]`" \
+          "File '$f' does not exist in index"
+      fi
+    else
+      if [[ "$f" =~ /$ ]]; then
+        ok "`[ $(git ls-tree --full-tree --name-only -r HEAD "$f") ]`" \
+          "Directory '$f' exists in index"
+      else
+        ok "`[ $(git ls-tree --full-tree --name-only -r HEAD "$f") ]`" \
+          "File '$f' exists in index"
+      fi
+    fi
+  done
+}
+
 test-gitrepo-comment-block() {
   is "$(grep -E '^;' $gitrepo)" "\
 ; DO NOT EDIT (unless you know what you are doing)


### PR DESCRIPTION
Usable with bare repositories (for checks on bare $UPSTREAM repos, to e.g. test if suprepo pushed a file successfully to $UPSTREAM).
Use example:

set -e
source test/setup
use Test::More
clone-foo-and-bar

test-exists \
  "$OWNER/foo/bar/Foo2" \
  "$OWNER/bar/Foo2" \

GIT_DIR="$UPSTREAM/bar" test-exists-in-index \
  "Foo2" \
  "bard" \
  "!Foo2" \
  "!bardz"

done_testing