### PR TITLE
Fix regression in fix of issue #98 related to submodule references

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -663,31 +663,17 @@ subrepo:commit() {
     fi
   fi
 
-  o "Remove old content of the subdir."
-  (
-    cd "./$subdir"
-    RUN rm -fr $(ls -A)
-  )
+  if git ls-files "$subdir" | grep -q .; then
+    o "Remove old content of the subdir."
+    RUN git rm -r "$subdir"
+  fi
 
   o "Put remote subrepo content into '$subdir/'."
-  GIT_WORK_TREE="$subdir" RUN git reset --hard "$subrepo_commit_ref"
-
-  o "Reset index to original commit."
-  if [ "$original_head_commit" != none ]; then
-    RUN git reset --mixed "$original_head_commit"
-  else
-    RUN git reset --mixed
-    # index currently considers $subdir content as deleted at root.
-    o "Delete the index."
-    local indexfile="${GIT_INDEX_FILE:-$(git rev-parse --git-dir)/index}"
-    RUN rm -f "$indexfile"
-  fi
+  RUN git read-tree --prefix="$subdir" -u "$subrepo_commit_ref"
 
   o "Put info into '$subdir/.gitrepo' file."
   update-gitrepo-file
-
-  o "Add '$subdir/' content to the index."
-  RUN git add -A "$subdir"
+  RUN git add "$gitrepo"
 
   o "Commit to the '$original_head_branch' branch."
   if [ "$original_head_commit" != none ]; then

--- a/test/subrepo-submodule.t
+++ b/test/subrepo-submodule.t
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Test that a subrepo that contains a submodule retains the submodule reference
+# so that the tree hash stays the same. (However, the subrepo's submodule won't
+# be directly usable since the .gitmodules file isn't in the top level.)
+
+set -e
+
+source test/setup
+
+use Test::More
+
+clone-foo-and-bar
+
+# Add submodule reference along with a new file to the bar repo:
+(
+  cd $OWNER/bar
+  git clone ../foo submodule
+  add-new-files file
+  git add submodule file
+  git commit --amend -C HEAD
+) &> /dev/null || die
+
+(
+  cd $OWNER/foo
+  git subrepo clone ../bar
+) &> /dev/null || die
+
+(
+  cd $OWNER/bar
+  modify-files file
+) &> /dev/null || die
+
+{
+  is "$(
+   cd $OWNER/foo
+    git subrepo pull bar
+  )" \
+    "Subrepo 'bar' pulled from '../bar' (master)." \
+    'subrepo pull command output is correct'
+}
+
+done_testing
+
+teardown


### PR DESCRIPTION
Fix for regression in the fix of issue #98 - when looking for a common ancestor using tree hashes, no ancestor can be found if the subrepo happens to have one or several submodule references (i.e., entries of type "commit" in the tree), so the pull will fail. "read-tree" retains the tree
pristine while "add" only retains blobs and trees.

Now, it might not sound very useful to have a subrepo with submodules, but in my case, I'm importing a third-party repo into my own, and I'm only interested in their main code, not their third-party
(fourth-party?) code.

I also added a new subrepo-submodule.t test that fails without the fix.