### PR TITLE
Use 'git rev-parse --show-prefix' to test if at top level.

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -1225,7 +1225,7 @@ assert-repo-is-ready() {
   fi
 
   # For now, only support actions from top of repo:
-  if [[ $(git rev-parse --git-dir) != .git ]]; then
+  if [[ -n "$(git rev-parse --show-prefix)" ]]; then
     error "Need to run subrepo command from top level directory of the repo."
   fi
 }


### PR DESCRIPTION
This check lets git-subrepo work within submodules (solving #124 )