### PR TITLE
Add prune-empty to the filter-branch command.

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -678,7 +678,7 @@ subrepo:branch() {
 
   o "Remove the .gitrepo file from the history."
   FAIL=false RUN git filter-branch -f \
-    --tree-filter "rm -f .gitrepo"
+    --prune-empty --tree-filter "rm -f .gitrepo"
 
   o "Create branch '$branch' for this new commit set."
   RUN git branch "$branch"

--- a/test/push-after-init.t
+++ b/test/push-after-init.t
@@ -6,15 +6,19 @@ source test/setup
 
 use Test::More
 
-git clone $UPSTREAM/init $OWNER/init &>/dev/null || die
-
+# Create directory and init git locally as this will test some corner
+# cases when you don't have any previous commits to rely on
+# see issue/122
 (
+  mkdir -p $OWNER/init
   cd $OWNER/init
+  git init
+  mkdir doc
+  add-new-files doc/FooBar
   git subrepo init doc || die
   mkdir ../upstream
   git init --bare ../upstream || die
-)
-# &> /dev/null
+) &> /dev/null
 
 output="$(
   cd $OWNER/init
@@ -39,7 +43,6 @@ gitrepo=$OWNER/init/doc/.gitrepo
 {
   test-exists \
     "$OWNER/up/.git/" \
-    "$OWNER/up/init.swim" \
     "!$OWNER/up/.gitrepo"
 }
 


### PR DESCRIPTION
This should solve #122 and make the branch command much better. It will clear out all empty commits caused by the `filter-branch --tree-filter`command. They could cause trouble for other cases then init.