### PR TITLE
Use git log -1 for a more efficient subdir check

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -1335,7 +1335,7 @@ assert-subdir-ready-for-init() {
     error "The subdir '$subdir' is already a subrepo."
   fi
   # Check that subdir is part of the repo
-  if [[ -z $(git log -- $subdir) ]]; then
+  if [[ -z $(git log -1 -- $subdir) ]]; then
     error "The subdir '$subdir' is not part of this repo."
   fi
 }


### PR DESCRIPTION
Remove an unnecessary delay when dealing with larger git histories.
Thanks