### PR TITLE
Fixes a bug that occurs when attempting to created nested subdirs

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -485,7 +485,11 @@ subrepo:init() {
 
   o "Create branch '$branch_name' for this new subrepo."
   FAIL=false RUN git branch -D "$branch_name"
-  RUN git branch "$branch_name"
+  FAIL=false RUN git branch "$branch_name"
+  if ! $OK; then
+    RUN git reset --hard "$original_head_commit"
+    error "Failed to 'git branch $branch_name'."
+  fi
 
   if [[ $subrepo_remote != none ]]; then
     o "Create subrepo remote 'subrepo/$subdir' -> '$subrepo_remote'."

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -1344,7 +1344,7 @@ assert-subdir-ready-for-init() {
     parentdir="$parentdir$dir/"
     if [[ -e $parentdir.gitrepo ]]; then
       error "The subdir '$subdir' is already part of another subrepo at "\
-"'$parentdir'."
+"'${parentdir%/}'."
     fi
   done
   # Check that subdir is part of the repo

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -1338,6 +1338,15 @@ assert-subdir-ready-for-init() {
   if [[ -e $subdir/.gitrepo ]]; then
     error "The subdir '$subdir' is already a subrepo."
   fi
+  # Check if subdir is already part of another subrepo.
+  parentdir=
+  for dir in $(echo "$subdir" | tr '/' '\n'); do
+    parentdir="$parentdir$dir/"
+    if [[ -e $parentdir.gitrepo ]]; then
+      error "The subdir '$subdir' is already part of another subrepo at "\
+"'$parentdir'."
+    fi
+  done
   # Check that subdir is part of the repo
   if [[ -z $(git log -1 -- $subdir) ]]; then
     error "The subdir '$subdir' is not part of this repo."

--- a/test/error.t
+++ b/test/error.t
@@ -196,6 +196,26 @@ clone-foo-and-bar
     "Error OK: clone non-repo"
 }
 
-done_testing 29
+{
+  is "$(
+      cd $OWNER/bar
+      git reset --quiet --hard HEAD^
+      git subrepo --quiet clone ../../../$UPSTREAM/foo
+      git subrepo --quiet branch foo
+      mkdir foo/sub
+      add-new-files foo/sub/file
+      catch git subrepo init foo/sub
+    )" \
+    "git-subrepo: The subdir 'foo/sub' is already part of another subrepo at 'foo'." \
+    "Error OK: can't create a subrepo inside of another subrepo"
+
+  (
+    cd $OWNER/bar
+    git subrepo --quiet clean foo
+    git reset --quiet --hard HEAD^
+  )
+}
+
+done_testing 30
 
 teardown


### PR DESCRIPTION
Fixes a bug that occurs when trying to create a subrepo inside of another subrepo.

###

Steps to reproduce:

$ find | grep -v '\.git'
.
./foo
./foo/bar
./foo/bar/Bar
./foo/Foo

$ git subrepo init foo
Subrepo created from 'foo' (with no remote).

$ git branch
* master
  subrepo/foo

$ git subrepo init foo/bar
git-subrepo: Command failed: 'git branch subrepo/foo/bar'.

$ find | grep -v '\.git'
.
./Bar

###

'git branch subrepo/foo/bar' fails because '.git/refs/heads/subrepo/foo' already exists as a file instead of a directory. Furthermore, when git branch fails, there is no catch, so the HEAD is stuck in the subdirectory-filter.

This PR properly handles the failed 'git branch' command, and prevents a subdir from being created inside of another subdir entirely.
Hopefully the test I wrote is in accordance with your standards.

Thanks
