### PR TITLE
Improve detection of remote default head branch

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -1398,7 +1398,7 @@ get-upstream-head-branch() {
   )"
   local branch=; branch="$(
     echo "$remotes" |
-    grep "$commit" |
+    grep -E "$commit[[:space:]]+refs/heads/" |
     grep -v HEAD |
     head -n1 |
     cut -f2


### PR DESCRIPTION
Multiple refs can point to the same commit as HEAD, and they might
appear before the refs/heads/... entry that we're looking for. This is
particularly the case with the code review system Gerrit, which can lead
to refs such as these:

c197bcf24cde29d3f73c7b4ac6fd41f4384e8af6	HEAD
...
c197bcf24cde29d3f73c7b4ac6fd41f4384e8af6	refs/changes/21/20821/3
...
c197bcf24cde29d3f73c7b4ac6fd41f4384e8af6	refs/heads/master

The old implementation would find the refs/changes/21/20821/3 ref, then
complain that it's not a refs/heads/... ref. By specifically looking
only for those refs that we'll accept, we improve the robustness of the
detection.