### PR TITLE
Loosen up regex to determine if pushing to a new repo after init

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -578,7 +578,7 @@ subrepo:push() {
     if ! OK; then
       # Check if we are pushing to a new upstream repo (or branch) and just
       # push the commit directly. This is common after a `git subrepo init`:
-      local re="^fatal: Couldn't find remote ref "
+      local re="fatal: Couldn't find remote ref "
       if [[ $output =~ $re ]]; then
         o "Pushing to new upstream: $subrepo_remote ($subrepo_branch)."
         RUN git push \


### PR DESCRIPTION
The push command expects the "fatal: Couldn't find remote ref" string to be present. However, all manner of various outputs from git could fail to match that string at the beginning of the output. This relaxes this restriction with the addde bonus that the commit message is longer than the change.

Example:
✔ ~/BitPusher/bookstore/bp-automation-merge [cluster/devops ↓·18↑·3|✔] 
17:55 $ git subrepo push chef/cookbooks/bp-aws-single-az-lb --force
git-subrepo: Fetch for push failed: Host key fingerprint is SHA256:SCBz9Sh537ZPrxSnRQRymcFY7W6FazDAhvTcwWoJiEM
+---[RSA 2048]----+
|  o.Eo.o.o.=**.  |
|   +oo.ooo=+=o.  |
|    o.+ .oo+.... |
|     + o .+ o.o .|
|      . S.o .+oo |
|         . . ==  |
|          . +o   |
|           + .   |
|            o..  |
+----[SHA256]-----+

User ynemoy authorized.
fatal: Couldn't find remote ref master
fatal: The remote end hung up unexpectedly
