### PR TITLE
Force .gitrepo add.

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -502,7 +502,7 @@ subrepo:init() {
   update-gitrepo-file
 
   o "Add the new '$subdir/.gitrepo' file."
-  RUN git add "$subdir/.gitrepo"
+  RUN git add -f "$subdir/.gitrepo"
 
   o "Commit new subrepo to the '$original_head_branch' branch."
   subrepo_commit_ref="$upstream_head_commit"
@@ -774,7 +774,7 @@ subrepo:commit() {
 
   o "Put info into '$subdir/.gitrepo' file."
   update-gitrepo-file
-  RUN git add "$gitrepo"
+  RUN git add -f "$gitrepo"
 
   o "Commit to the '$original_head_branch' branch."
   if [[ $original_head_commit != none ]]; then


### PR DESCRIPTION
If the container repo has a .gitignore which contains a rule that, possibly by chance, ignores the .gitrepo file, then the subrepo clone command fails. The `add -f` (force) fixes the issue.
