### PR TITLE
Fix length comparison operators in `merge-base`

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -809,7 +809,7 @@ subrepo:merge-base() {
   for entry in ${merge_base_order[@]}; do
     local source_key="${source}_$entry"
     local source_value="${!source_key}"
-    if [[ ${#source_value} > 40 ]]; then
+    if [[ ${#source_value} -gt 40 ]]; then
       if $list_all; then
         say "Multiple on $1: $source_value"
       fi
@@ -820,7 +820,7 @@ subrepo:merge-base() {
         :
       else
         local target_value=${!target_key};
-        if [[ ${#target_value} > 40 ]]; then
+        if [[ ${#target_value} -gt 40 ]]; then
           if $list_all; then
             say "Multiple on $2: $target_value"
           fi


### PR DESCRIPTION
I'm not entirely clear on when this will be necessary (not enough time to trace the code), but it's the state I found my repo in. If anyone who understands the context better wants to supply a regression test, or even supply context so I can write a regression test, be my guest.
