### PR TITLE
Don't reuse previous commit message when using --all

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -120,7 +120,7 @@ main() {
   local override_branch=        # Remote specified with -b
 
   local edit_wanted=false       # Edit commit message using -e
-  local commit_message=         # Custom commit message using -m
+  local wanted_commit_message=  # Custom commit message using -m
 
   local FAIL=true               # Flag for RUN: fail on error
   local OUT=false               # Flag for RUN: put output in $output
@@ -750,7 +750,12 @@ subrepo:commit() {
   o "Put info into '$subdir/.gitrepo' file."
   update-gitrepo-file
 
-  [[ -n $commit_message ]] || commit_message="$(get-commit-message)"
+  local commit_message
+  if [[ -n "$wanted_commit_message" ]]; then
+    commit_message="$wanted_commit_message"
+  else
+    commit_message="$(get-commit-message)"
+  fi
 
   local edit_flag=
   $edit_wanted && edit_flag=--edit
@@ -913,7 +918,7 @@ get-command-options() {
       -f) force_wanted=true
           commit_msg_args+=("--force") ;;
       -F) fetch_wanted=true ;;
-      -m) commit_message="$1"
+      -m) wanted_commit_message="$1"
           shift;;
       -N) dry_run_wanted=true ;;
       -r) subrepo_remote="$1"
@@ -963,7 +968,7 @@ get-command-options() {
   if [[ -n $override_remote ]]; then
     check_option remote
   fi
-  if [[ -n $commit_message ]]; then
+  if [[ -n $wanted_commit_message ]]; then
     check_option message
   fi
   if $update_wanted; then


### PR DESCRIPTION
Before this fix, all commits for pulled subrepos would get the same message (created for the first repo) when using the -a/--all option.
