### PR TITLE
Combine filter-branch operations and switch to index-filter

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -737,14 +737,11 @@ subrepo:branch() {
   o "Check if the '$branch' branch already exists."
   git:branch-exists "$branch" && return
 
-  o "Get commits specific to the subdir."
+  o "Get commits specific to the subdir, excluding the .gitrepo file."
   FAIL=false RUN git filter-branch -f \
-    --subdirectory-filter "$subdir" \
+    --index-filter "git rm -f --cached --ignore-unmatch .gitrepo" \
+    --prune-empty --subdirectory-filter "$subdir" \
     HEAD
-
-  o "Remove the .gitrepo file from the history."
-  FAIL=false RUN git filter-branch -f \
-    --prune-empty --tree-filter "rm -f .gitrepo"
 
   o "Create branch '$branch' for this new commit set."
   RUN git branch "$branch"


### PR DESCRIPTION
In my own custom tools that user filter-branch, I've been able to use index-filter instead of tree-filter, and then combine it with subdirectory-filter to only run filter-branch once. This doubles the speed for those branch operations, which makes a huge difference in the larger repos I work with.