### PR TITLE
Ask git to find the .gitrepo files

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -1504,15 +1504,7 @@ assert-subdir-empty() {
 # Find all the current subrepos by looking for all the subdirectories that
 # contain a `.gitrepo` file.
 get-all-subrepos() {
-  local paths=();
-  paths=($(
-    git ls-files |
-      grep '.gitrepo$' |
-      grep -v '/.git/' |
-      grep '/.gitrepo$' |
-      sed 's/.gitrepo$//' |
-      sort
-  ))
+  local paths=($(git ls-files | sed -n 's!/\.gitrepo$!!p' | sort))
   subrepos=()
   local path
   for path in "${paths[@]}"; do

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -1504,8 +1504,10 @@ assert-subdir-empty() {
 # Find all the current subrepos by looking for all the subdirectories that
 # contain a `.gitrepo` file.
 get-all-subrepos() {
-  local paths=($(
-    find . -name '.gitrepo' |
+  local paths=();
+  paths=($(
+    git ls-files |
+      grep '.gitrepo$' |
       grep -v '/.git/' |
       grep '/.gitrepo$' |
       sed 's/.gitrepo$//' |


### PR DESCRIPTION
Using `find .` can (a) take a long time and (b) go outside the current
repo.

Using `git ls-files` is inordinately faster, and only shows subrepos
of the current repo.