### PR TITLE
Fix #313: Ensured "-u" options is respected by "subrepo:push()".

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -664,11 +664,13 @@ subrepo:push() {
     git:delete-branch "$branch_name"
   fi
 
-  o "Put updates into '$subdir/.gitrepo' file."
-  upstream_head_commit="$new_upstream_head_commit"
-  subrepo_commit_ref="$upstream_head_commit"
-  update-gitrepo-file
-  RUN git commit -m "$(get-commit-message)"
+  if $update_wanted; then
+    o "Put updates into '$subdir/.gitrepo' file."
+    upstream_head_commit="$new_upstream_head_commit"
+    subrepo_commit_ref="$upstream_head_commit"
+    update-gitrepo-file
+    RUN git commit -m "$(get-commit-message)"
+  fi
 }
 
 # Fetch the subrepo's remote branch content:


### PR DESCRIPTION
This is supposed to fix https://github.com/ingydotnet/git-subrepo/issues/313.