### PR TITLE
Report an error when the subrepo parent not found.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,9 @@ sudo: false
 # Want 'bash' but 'c' works:
 language: c
 
-branches:
-  only:
-  - master
-  - /^release\//
-
 script:
-- git checkout $(
-    git branch --contains HEAD
-        | cut -c3-
-        | grep -E '^(master$|release)'
-        | head -1
-  )
+# NOTE: we have to make sure we're on a branch (rather than on a detached HEAD) because tests rely on it.
+- git checkout -b travis-ci-dummy-branch-name
 - GIT_COMMITTER_NAME=Bob
   GIT_COMMITTER_EMAIL=bob@blob.net
   GIT_AUTHOR_NAME='Bob Blob'

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -706,6 +706,11 @@ subrepo:branch() {
     o "Create new commits with parents into the subrepo fetch"
     OUT=true RUN git rev-list --reverse --ancestry-path "$subrepo_parent..HEAD"
     local commit_list="$output"
+
+    if [ -z "$commit_list" ]; then
+      error "Could not find the parent commit '$subrepo_parent' for subrepo '$subref' in the history of the current HEAD. Please manually chose a new parent and edit '$subdir/.gitrepo'."
+    fi
+
     for commit in $commit_list; do
       o "Working on $commit"
 

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -531,7 +531,6 @@ subrepo:pull() {
   local branch_name="subrepo/$subref"
   git:delete-branch "$branch_name"
 
-  subrepo_parent="HEAD^"
   subrepo_commit_ref="$branch_name"
 
   o "Create subrepo branch '$branch_name'."


### PR DESCRIPTION
The subrepo parent may not be in the history if someone rebased their commits prior to the subrepo pull.

This change instructs the user what to do in this case.