### PR TITLE
Fixes Travis CI build. It was not checking out a branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,9 @@ sudo: false
 # Want 'bash' but 'c' works:
 language: c
 
-branches:
-  only:
-  - master
-  - /^release\//
-
 script:
-- git checkout $(
-    git branch --contains HEAD
-        | cut -c3-
-        | grep -E '^(master$|release)'
-        | head -1
-  )
+# NOTE: we have to make sure we're on a branch (rather than on a detached HEAD) because tests rely on it.
+- git checkout -b travis-ci-dummy-branch-name
 - GIT_COMMITTER_NAME=Bob
   GIT_COMMITTER_EMAIL=bob@blob.net
   GIT_AUTHOR_NAME='Bob Blob'


### PR DESCRIPTION
The command in `.travis.yml` that is supposed to checkout the branch did not actually check out the branch.