### PR TITLE
Make “git subrepo clean -f ...” delete refs correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,9 @@ sudo: false
 # Want 'bash' but 'c' works:
 language: c
 
-branches:
-  only:
-  - master
-  - /^release\//
-
 script:
-- git checkout $(
-    git branch --contains HEAD
-        | cut -c3-
-        | grep -E '^(master$|release)'
-        | head -1
-  )
+# NOTE: we have to make sure we're on a branch (rather than on a detached HEAD) because tests rely on it.
+- git checkout -b travis-ci-dummy-branch-name
 - GIT_COMMITTER_NAME=Bob
   GIT_COMMITTER_EMAIL=bob@blob.net
   GIT_AUTHOR_NAME='Bob Blob'

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -962,11 +962,15 @@ subrepo:clean() {
 
   if "$force_wanted"; then
     o "Remove all subrepo refs."
-    if "$all_wanted"; then
-      RUN rm -fr .git/refs/subrepo/
-    else
-      RUN rm -fr .git/refs/subrepo/$subref/
+    local suffix=""
+    if ! $all_wanted; then
+      suffix="$subref/"
     fi
+    git show-ref | while read hash ref; do
+      if [[ "$ref" == refs/subrepo/$suffix* ]]; then
+        git update-ref -d "$ref"
+      fi
+    done
   fi
 }
 


### PR DESCRIPTION
Since Git can store refs in packed form (see git-pack-refs(1)), use `git update-ref -d` to delete refs instead of assuming that they are stored in the `.git/refs` directory.