### PR TITLE
Make subrepo work when run in a worktree

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -28,7 +28,7 @@ bash+:import :std can
 
 VERSION=0.4.0
 REQUIRED_GIT_VERSION=2.7.0
-GIT_TMP=.git/tmp
+GIT_TMP="$(git rev-parse --git-common-dir 2> /dev/null || echo .git)/tmp"
 
 # `git rev-parse` turns this into a getopt parser and a command usage message:
 GETOPT_SPEC="\

--- a/test/pull-worktree.t
+++ b/test/pull-worktree.t
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -e
+
+source test/setup
+
+use Test::More
+
+clone-foo-and-bar
+
+(
+  cd $OWNER/foo
+  git subrepo clone ../bar bar
+  git worktree add -b test ../wt
+) &> /dev/null || die
+
+(
+  cd $OWNER/bar
+  modify-files Bar
+) &> /dev/null || die
+
+(
+  cd $OWNER/wt
+  git subrepo pull --all
+) &> /dev/null || die
+
+(
+  cd $OWNER/foo
+  git merge test
+) &> /dev/null || die
+
+{
+  is "$(cat $OWNER/foo/bar/Bar)" \
+    "a new line" \
+    'bar/Bar content correct'
+}
+
+done_testing
+
+teardown


### PR DESCRIPTION
In a worktree (created with git worktree add) there is no .git directory. It is
instead a file. To make subrepo work correctly in that case, use the
--git-common-dir argument to git rev-parse to find the path to the .git
directory. In a regular directory it just prints .git, but in a worktree it
prints the full path to the .git directory.

Fix #361