### PR TITLE
Fix error message to ensure output of $upstream_head_commit

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -646,8 +646,8 @@ subrepo:push() {
   if ! $force_wanted; then
     o "Make sure '$branch_name' contains the '$refs_subrepo_fetch' HEAD."
     if ! git:commit-in-rev-list "$upstream_head_commit" "$branch_name"; then
-      error "Can't commit: '$branch_name' doesn't contain upstream HEAD: " \
-        "$upstream_head_commit"
+      error "Can't commit: '$branch_name' doesn't contain upstream HEAD: \
+$upstream_head_commit"
     fi
   fi
 


### PR DESCRIPTION
I noticed a mistake in error function argument. It does not take two arguments so this line fails to print the value of `$upstream_head_commit`.
Log of the debugging is as follows.
```
+ error 'Can'\''t commit: '\''subrepo/public'\'' doesn'\''t contain upstream HEAD: ' b8f5ff2cc72506d4e2e7bc9373377faffd201cf8
+ local 'msg=git-subrepo: Can'\''t commit: '\''subrepo/public'\'' doesn'\''t contain upstream HEAD: ' usage=
+ echo -e 'git-subrepo: Can'\''t commit: '\''subrepo/public'\'' doesn'\''t contain upstream HEAD: '
git-subrepo: Can't commit: 'subrepo/public' doesn't contain upstream HEAD: 
+ exit 1
```