### PR TITLE
Remove conflicting -C from install -d commands.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,11 @@ test:
 
 # Install support:
 install:
-	install -C -d -m 0755 $(INSTALL_LIB)/
+	install -d -m 0755 $(INSTALL_LIB)/
 	install -C -m 0755 $(LIB) $(INSTALL_LIB)/
-	install -C -d -m 0755 $(INSTALL_EXT)/
+	install -d -m 0755 $(INSTALL_EXT)/
 	install -C -m 0755 $(EXTS) $(INSTALL_EXT)/
-	install -C -d -m 0755 $(INSTALL_MAN1)/
+	install -d -m 0755 $(INSTALL_MAN1)/
 	install -C -m 0644 $(MAN1)/$(NAME).1 $(INSTALL_MAN1)/
 
 # Uninstall support:


### PR DESCRIPTION
On macOS 10.14.5 install, which is the BSD version, complains

```
install: the -d and -C options may not be specified together
```

so this PR removes the pointless `-C` option. `-d` is used to create a directory. No copying, -C, is done. 