### PR TITLE
Fix #410 Push empty repositories with recent git versions

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -581,8 +581,9 @@ subrepo:push() {
     if ! OK; then
       # Check if we are pushing to a new upstream repo (or branch) and just
       # push the commit directly. This is common after a `git subrepo init`:
-      local re="(^|"$'\n'")fatal: Couldn't find remote ref "
-      if [[ $output =~ $re ]]; then
+      # Force to case in
+      local re="(^|"$'\n'")fatal: couldn't find remote ref "
+      if [[ ${output,,} =~ $re ]]; then
         o "Pushing to new upstream: $subrepo_remote ($subrepo_branch)."
         new_upstream=true
       else


### PR DESCRIPTION
Git 2.21 (possibly earlier) changed the output of the error for
empty repos from Couldn't to couldn't. Make the regex case
insensitive.