### PR TITLE
Fix parent update

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -114,6 +114,7 @@ main() {
   local subrepo_branch=         # Upstream branch to clone/push/pull
   local subrepo_commit=         # Upstream HEAD from previous clone/pull
   local subrepo_parent=         # Local commit from before previous clone/pull
+  local subrepo_push_parent=    # Local commit from before previous push
   local subrepo_former=         # A retired gitrepo key that might still exist
 
   local refs_subrepo_branch=    # A subrepo ref -> commit of branch/pull command
@@ -494,7 +495,7 @@ subrepo:clone() {
 
   o "Commit the new '$subdir/' content."
   subrepo_commit_ref="$upstream_head_commit"
-  CALL subrepo:commit
+  CALL subrepo:commit clone		
 }
 
 # Init a new subrepo from current repo:
@@ -604,10 +605,12 @@ subrepo:push() {
     if $squash_wanted; then
       o "Squash commits"
       subrepo_parent="HEAD^"
+		elif [ -n "$subrepo_push_parent" ]; then
+			subrepo_parent=$subrepo_push_parent
     fi
 
     o "Create subrepo branch '$branch_name'."
-    CALL subrepo:branch "$branch_name"
+    CALL subrepo:branch "$branch_name" 
     cd "$worktree";
 
     if [[ "$join_method" == "rebase" ]]; then
@@ -669,6 +672,8 @@ subrepo:push() {
   upstream_head_commit="$new_upstream_head_commit"
   subrepo_commit_ref="$upstream_head_commit"
   update-gitrepo-file
+	RUN git config --file="$gitrepo" subrepo.push-parent "$original_head_commit"
+	RUN git add  -f -- "$gitrepo"
   RUN git commit -m "$(get-commit-message)"
 }
 
@@ -693,6 +698,7 @@ subrepo:fetch() {
 # Create a subrepo branch containing all changes
 subrepo:branch() {
   local branch="${1:-"subrepo/$subref"}"
+				
   o "Check if the '$branch' branch already exists."
   git:branch-exists "$branch" && return
 
@@ -807,6 +813,7 @@ subrepo:branch() {
 
 # Commit a merged subrepo branch:
 subrepo:commit() {
+	local is_clone=$1
   o "Check that '$subrepo_commit_ref' exists."
   git:rev-exists "$subrepo_commit_ref" ||
     error "Commit ref '$subrepo_commit_ref' does not exist."
@@ -830,6 +837,9 @@ subrepo:commit() {
 
   o "Put info into '$subdir/.gitrepo' file."
   update-gitrepo-file
+	if [ "$is_clone" == "clone" ]; then
+		RUN git config --file="$gitrepo" subrepo.push-parent "$original_head_commit"
+	fi
   RUN git add -f -- "$gitrepo"
 
   local commit_message
@@ -1321,6 +1331,10 @@ read-gitrepo-file() {
   FAIL=false \
   SAY=false OUT=true RUN git config --file="$gitrepo" subrepo.parent
   subrepo_parent="$output"
+
+  FAIL=false \
+  SAY=false OUT=true RUN git config --file="$gitrepo" subrepo.push-parent
+  subrepo_push_parent="$output"
 
   FAIL=false \
   SAY=false OUT=true RUN git config --file="$gitrepo" subrepo.method

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -941,6 +941,10 @@ subrepo:status() {
       printf "  Former Commit:   $(git rev-parse --short $subrepo_former)"
       echo " *** DEPRECATED ***"
     fi
+    [[ -n $subrepo_push_parent ]] &&
+      echo "  Push Parent:     $(git rev-parse --short $subrepo_push_parent)"
+
+			
 
     # Grep for directory, branch can be in detached state due to conflicts
     local _worktree=$(git worktree list | grep "$GIT_TMP/subrepo/$subdir")

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -704,7 +704,7 @@ subrepo:branch() {
     local prev_commit=
     local ancestor=
     o "Create new commits with parents into the subrepo fetch"
-    OUT=true RUN git rev-list --reverse --ancestry-path "$subrepo_parent..HEAD"
+    OUT=true RUN git rev-list --reverse --ancestry-path  "$subrepo_parent..HEAD"
     local commit_list="$output"
     for commit in $commit_list; do
       o "Working on $commit"
@@ -1374,13 +1374,20 @@ update-gitrepo-file() {
   fi
 
   RUN git config --file="$gitrepo" subrepo.commit "$upstream_head_commit"
+	o " upstream_head_commit:'$upstream_head_commit', subrepo_commit_ref='$subrepo_commit_ref'"
+
   # Only write new parent when we are at the head of upstream
-  if [[ -n $upstream_head_commit && -n $subrepo_commit_ref ]]; then
-    OUT=true RUN git rev-parse "$subrepo_commit_ref"
-    o "$upstream_head_commit == $output"
-    if [[ $upstream_head_commit == $output ]]; then
-      RUN git config --file="$gitrepo" subrepo.parent "$original_head_commit"
-    fi
+  if [[ -n $upstream_head_commit && -n $subrepo_commit_ref && -n $original_head_commit ]]; then
+		#
+		# srg: this check prevents from updating the parent after pull
+		#
+    # OUT=true RUN git rev-parse "$subrepo_commit_ref"
+    # o "$upstream_head_commit == $output"
+    # if [[ $upstream_head_commit == $output ]]; then
+
+		RUN git config --file="$gitrepo" subrepo.parent "$original_head_commit"
+
+		#fi
   fi
 
   [[ -z $join_method ]] && join_method="merge"

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -581,7 +581,7 @@ subrepo:push() {
     if ! OK; then
       # Check if we are pushing to a new upstream repo (or branch) and just
       # push the commit directly. This is common after a `git subrepo init`:
-      local re="(^|"$'\n'")fatal: Couldn't find remote ref "
+      local re="(^|"$'\n'")fatal: [Cc]ouldn't find remote ref "
       if [[ $output =~ $re ]]; then
         o "Pushing to new upstream: $subrepo_remote ($subrepo_branch)."
         new_upstream=true

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -671,9 +671,9 @@ subrepo:push() {
   o "Put updates into '$subdir/.gitrepo' file."
   upstream_head_commit="$new_upstream_head_commit"
   subrepo_commit_ref="$upstream_head_commit"
-  update-gitrepo-file
-	RUN git config --file="$gitrepo" subrepo.push-parent "$original_head_commit"
-	RUN git add  -f -- "$gitrepo"
+  update-gitrepo-file "push"
+	# RUN git config --file="$gitrepo" subrepo.push-parent "$original_head_commit"
+	# RUN git add  -f -- "$gitrepo"
   RUN git commit -m "$(get-commit-message)"
 }
 
@@ -836,11 +836,14 @@ subrepo:commit() {
   RUN git read-tree --prefix="$subdir" -u "$subrepo_commit_ref"
 
   o "Put info into '$subdir/.gitrepo' file."
-  update-gitrepo-file
-	if [ "$is_clone" == "clone" ]; then
-		RUN git config --file="$gitrepo" subrepo.push-parent "$original_head_commit"
-	fi
-  RUN git add -f -- "$gitrepo"
+	local push_update=
+  [ "$is_clone" == "clone" ] && push_update="push"
+  update-gitrepo-file "$push_update"
+
+	# if [ "$is_clone" == "clone" ]; then
+	# 	RUN git config --file="$gitrepo" subrepo.push-parent "$original_head_commit"
+	# fi
+  # RUN git add -f -- "$gitrepo"
 
   local commit_message
   if [[ -n "$wanted_commit_message" ]]; then
@@ -1360,7 +1363,8 @@ read-gitrepo-file() {
 # Update the subdir/.gitrepo state file:
 update-gitrepo-file() {
   local short_commit=
-
+  local is_push=$1
+	
   local newfile=false
   if [[ ! -e $gitrepo ]]; then
 
@@ -1404,7 +1408,9 @@ update-gitrepo-file() {
     # if [[ $upstream_head_commit == $output ]]; then
 
 		RUN git config --file="$gitrepo" subrepo.parent "$original_head_commit"
-
+		if [ "$is_push" == "push" ]; then
+				RUN git config --file="$gitrepo" subrepo.push-parent "$original_head_commit"
+		fi
 		#fi
   fi
 

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -704,7 +704,7 @@ subrepo:branch() {
     local prev_commit=
     local ancestor=
     o "Create new commits with parents into the subrepo fetch"
-    OUT=true RUN git rev-list --reverse --ancestry-path  "$subrepo_parent..HEAD"
+    OUT=true RUN git rev-list --reverse --ancestry-path --topo-order "$subrepo_parent..HEAD"
     local commit_list="$output"
     for commit in $commit_list; do
       o "Working on $commit"

--- a/test/error.t
+++ b/test/error.t
@@ -117,8 +117,10 @@ clone-foo-and-bar
 
 {
   is "$(
-      cd .git
-      catch git subrepo status
+     # the test was failing inside a submodule. there is no .git directory, just a ref
+     # cd .git
+     cd $(git rev-parse --git-dir)
+     catch git subrepo status
     )" \
     "git-subrepo: Can't 'subrepo status' outside a working tree." \
     "Error OK: check inside working tree"

--- a/test/pull-merge.t
+++ b/test/pull-merge.t
@@ -27,7 +27,8 @@ gitrepo=$OWNER/foo/bar/.gitrepo
   test-gitrepo-field "parent" "$foo_pull_commit"
 }
 
-foo_pull_commit="$(cd $OWNER/foo; git rev-parse HEAD)"
+## i think this wrong and the parent should be moved after the pull
+#foo_pull_commit="$(cd $OWNER/foo; git rev-parse HEAD)"
 
 (
   cd $OWNER/foo
@@ -35,6 +36,9 @@ foo_pull_commit="$(cd $OWNER/foo; git rev-parse HEAD)"
   modify-files-ex bar/Bar2
   git push
 ) &> /dev/null || die
+
+#this is the right place
+foo_pull_commit="$(cd $OWNER/foo; git rev-parse HEAD)"
 
 (
   cd $OWNER/bar


### PR DESCRIPTION
I had found that the parent pointer does not change after the pull. As a result, the next pull does re-sampling of old commits and ends up in merge conflicts in some cases. To fix the issue, i commented out the extra check in the update-gitrepo-file (# if [[ $upstream_head_commit == $output ]]; then). 

This works in all my cases. It also works in all tests but "pull-merge.t".  The test did sample the parent before pull. So, i modified it to sample the parent after the pull.

There was also an issue with 'push.t'. The push after pull had truncated history, because the parent pointer had been moved before the push is done. The solution for the issue was to add yet another parent pointer as 'push-parent'. So, the .gitrepo has another entry now. 

On the way i had fixed a few issues:

1. git 2.21 changed word casing in the 'Cc]ouldn't find remote ref' message. I fixed  the regex

1. branch... tests were failing sporadically at least with git 2.22. The order of transactions reported by rev-list in presence of branches was different from test to test. looks like --topo-order fixed it.

1.  error.t was failing inside a submodule, because there was a ref to '.dir'.  So, the 'cd' command failed. I fixed the test.  


  
