### PR TITLE
Avoid git filter-branch delay

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -8,7 +8,7 @@
 # Exit on any errors:
 set -e
 
-export FILTER_BRANCH_SQUELCH=1
+export FILTER_BRANCH_SQUELCH_WARNING=1
 
 # Import Bash+ helper functions:
 SOURCE="$BASH_SOURCE"


### PR DESCRIPTION
In recent git versions, git filter-branch prints a message to use other tools and waits for the user to press Ctrl-C. Since git-subrepo uses filter-branch sensibly and doesn't show the message to the user, there's no need for this delay. Setting FILTER_BRANCH_SQUELCH disables it.

Fixes #430.