### PR TITLE
Use git-filter-branch --index-filter instead of --tree-filter

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -816,8 +816,8 @@ subrepo:branch() {
   o "Remove the .gitrepo file from $first_gitrepo_commit..$branch"
   local filter=$branch
   [[ $first_gitrepo_commit ]] && filter=$first_gitrepo_commit..$branch
-  FAIL=false RUN git filter-branch -f --prune-empty --tree-filter \
-    "rm -f .gitrepo" "$filter"
+  FAIL=false RUN git filter-branch -f --prune-empty --index-filter \
+    'git rm --cached --ignore-unmatch .gitrepo' "$filter"
 
   git:create-worktree "$branch"
 


### PR DESCRIPTION
Using an index filter is much faster since git does not have to perform
a full checkout for every commit in the range that needs to be rewritten.

Fixes #435