### PR TITLE
Fix error when sourcing .rc with old zsh version

### DIFF
--- a/.rc
+++ b/.rc
@@ -13,7 +13,7 @@
 #
 #------------------------------------------------------------------------------
 
-if [[ ${BASH_VERSION} ]]; then
+if [[ -n ${BASH_VERSION-} ]]; then
   if [[ ${BASH_VERSINFO[0]} -lt 4 ]] ; then
     echo "The git-subrepo command requires that 'Bash 4+' is installed."
     echo "It doesn't need to be your shell, but it must be in your PATH."


### PR DESCRIPTION
zsh 5.0.2 has trouble parsing `[[ ${BASH_VERSION} ]]` (see 27f51ea8e7927) in the .rc file:

```bash
% zsh --version
zsh 5.0.2 (x86_64-redhat-linux-gnu)
% source git-subrepo/.rc
git-subrepo/.rc:16: parse error near `]]'
```
