### PR TITLE
Add a fish shell startup script

### DIFF
--- a/.fish.rc
+++ b/.fish.rc
@@ -1,0 +1,16 @@
+#!fish
+
+#------------------------------------------------------------------------------
+#
+# This is the `git-subrepo` initialization script.
+#
+# This script turns on the `git-subrepo` Git subcommand for the *Fish* shell.
+#
+# Just add a line like this to your `~/.config/fish/config.fish`:
+#
+#   source /path/to/git-subrepo/.fish.rc
+#
+#------------------------------------------------------------------------------
+
+set GIT_SUBREPO_ROOT (readlink -f (dirname (status --current-filename)))
+set PATH $GIT_SUBREPO_ROOT/lib $PATH

--- a/.fish.rc
+++ b/.fish.rc
@@ -4,7 +4,8 @@
 #
 # This is the `git-subrepo` initialization script.
 #
-# This script turns on the `git-subrepo` Git subcommand for the *Fish* shell.
+# This script turns on the `git-subrepo` Git subcommand and its manpages, for
+# the *Fish* shell.
 #
 # Just add a line like this to your `~/.config/fish/config.fish`:
 #
@@ -14,3 +15,6 @@
 
 set GIT_SUBREPO_ROOT (readlink -f (dirname (status --current-filename)))
 set PATH $GIT_SUBREPO_ROOT/lib $PATH
+
+set -q MANPATH || set MANPATH ''
+set MANPATH $MANPATH $GIT_SUBREPO_ROOT/man


### PR DESCRIPTION
This adds the subrepo command, but adding to the MANPATH variable in fish seems to cause manpages to not work for other things, from anecdotal evidence. Bash completion clearly doesn't work, but is something that could be done for fish shell at a later point, as fish shell completion definitions.

Since most of subrepo is executed explicitly with bash, it seems to work fine in fish shell as far as I can tell, besides the need for a fish rc file, as added in this commit.