### PR TITLE
Fix fish.rc file to work on mac os

### DIFF
--- a/.fish.rc
+++ b/.fish.rc
@@ -13,7 +13,7 @@
 #
 #------------------------------------------------------------------------------
 
-set GIT_SUBREPO_ROOT (readlink -f (dirname (status --current-filename)))
+set GIT_SUBREPO_ROOT (dirname (realpath (status --current-filename)))
 set PATH $GIT_SUBREPO_ROOT/lib $PATH
 
 set -q MANPATH || set MANPATH ''


### PR DESCRIPTION
Unfortunately mac os has bsd variant of readlink, which doesn't support -f

Use realpath which is more universal, checked on mac os and centos 7
Fixes #450