### PR TITLE
Fix unreliable branch existence check

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -955,7 +955,7 @@ subrepo:clean() {
 
   o "Clean $subdir"
   git:remove-worktree
-  if [[ -e .git/$ref ]]; then
+  if git:branch-exists "$branch"; then
     o "Remove branch '$branch'."
     RUN git update-ref -d "$ref"
     clean_list+=("branch '$branch'")


### PR DESCRIPTION
It can sometimes be the case that `.git/refs/heads/subrepo/mylib` is not present even though branch `subrepo/mylib` does actually exist.
This change fixes that and makes the code more consistent by re-using an existing function.