### PR TITLE
Don't suppress stderr when git merge fails

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -549,7 +549,7 @@ subrepo:pull() {
     fi
   else
     o "Merge in changes from $refs_subrepo_fetch"
-    FAIL=false OUT=true RUN git merge "$refs_subrepo_fetch"
+    FAIL=false RUN git merge "$refs_subrepo_fetch"
     if ! OK; then
       say "The \"git merge\" command failed:"
       say


### PR DESCRIPTION
If `git merge` fails for whatever reason and prints the error on `stderr` the current implementation silently discards it, leaving the user with no idea what went wrong. There's no advantage in discarding `stderr` in this case.