### PR TITLE
Override date format in all git log commands. Fixes #383

### DIFF
--- a/.fish.rc
+++ b/.fish.rc
@@ -13,7 +13,7 @@
 #
 #------------------------------------------------------------------------------
 
-set GIT_SUBREPO_ROOT (readlink -f (dirname (status --current-filename)))
+set GIT_SUBREPO_ROOT (dirname (realpath (status --current-filename)))
 set PATH $GIT_SUBREPO_ROOT/lib $PATH
 
 set -q MANPATH || set MANPATH ''

--- a/.fish.rc
+++ b/.fish.rc
@@ -1,0 +1,16 @@
+#!fish
+
+#------------------------------------------------------------------------------
+#
+# This is the `git-subrepo` initialization script.
+#
+# This script turns on the `git-subrepo` Git subcommand for the *Fish* shell.
+#
+# Just add a line like this to your `~/.config/fish/config.fish`:
+#
+#   source /path/to/git-subrepo/.fish.rc
+#
+#------------------------------------------------------------------------------
+
+set GIT_SUBREPO_ROOT (readlink -f (dirname (status --current-filename)))
+set PATH $GIT_SUBREPO_ROOT/lib $PATH

--- a/.fish.rc
+++ b/.fish.rc
@@ -4,7 +4,8 @@
 #
 # This is the `git-subrepo` initialization script.
 #
-# This script turns on the `git-subrepo` Git subcommand for the *Fish* shell.
+# This script turns on the `git-subrepo` Git subcommand and its manpages, for
+# the *Fish* shell.
 #
 # Just add a line like this to your `~/.config/fish/config.fish`:
 #
@@ -14,3 +15,6 @@
 
 set GIT_SUBREPO_ROOT (readlink -f (dirname (status --current-filename)))
 set PATH $GIT_SUBREPO_ROOT/lib $PATH
+
+set -q MANPATH || set MANPATH ''
+set MANPATH $MANPATH $GIT_SUBREPO_ROOT/man

--- a/.rc
+++ b/.rc
@@ -13,7 +13,7 @@
 #
 #------------------------------------------------------------------------------
 
-if [[ ${BASH_VERSION} ]]; then
+if [[ -n ${BASH_VERSION-} ]]; then
   if [[ ${BASH_VERSINFO[0]} -lt 4 ]] ; then
     echo "The git-subrepo command requires that 'Bash 4+' is installed."
     echo "It doesn't need to be your shell, but it must be in your PATH."

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -8,7 +8,7 @@
 # Exit on any errors:
 set -e
 
-export FILTER_BRANCH_SQUELCH=1
+export FILTER_BRANCH_SQUELCH_WARNING=1
 
 # Import Bash+ helper functions:
 SOURCE="$BASH_SOURCE"

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -957,7 +957,7 @@ subrepo:clean() {
 
   o "Clean $subdir"
   git:remove-worktree
-  if [[ -e .git/$ref ]]; then
+  if git:branch-exists "$branch"; then
     o "Remove branch '$branch'."
     RUN git update-ref -d "$ref"
     clean_list+=("branch '$branch'")

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -551,7 +551,7 @@ subrepo:pull() {
     fi
   else
     o "Merge in changes from $refs_subrepo_fetch"
-    FAIL=false OUT=true RUN git merge "$refs_subrepo_fetch"
+    FAIL=false RUN git merge "$refs_subrepo_fetch"
     if ! OK; then
       say "The \"git merge\" command failed:"
       say

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -767,7 +767,7 @@ subrepo:branch() {
         o "Create with content"
         local PREVIOUS_IFS=$IFS
         IFS=$'\n'
-        local author_info=( $(git log -1 --format=%ad%n%ae%n%an "$commit") )
+        local author_info=( $(git log -1 --date=default --format=%ad%n%ae%n%an "$commit") )
         IFS=$PREVIOUS_IFS
 
         # When we create new commits we leave the author information unchanged
@@ -775,7 +775,7 @@ subrepo:branch() {
         # This should be analog how cherrypicking is handled allowing git
         # to store both the original author but also the responsible committer
         # that created the local version of the commit and pushed it.
-        prev_commit=$(git log -n 1 --format=%B "$commit" |
+        prev_commit=$(git log -n 1 --date=default --format=%B "$commit" |
           GIT_AUTHOR_DATE="${author_info[0]}" \
           GIT_AUTHOR_EMAIL="${author_info[1]}" \
           GIT_AUTHOR_NAME="${author_info[2]}" \
@@ -1503,7 +1503,7 @@ assert-subdir-ready-for-init() {
     error "The subdir '$subdir' is already a subrepo."
   fi
   # Check that subdir is part of the repo
-  if [[ -z $(git log -1 -- $subdir) ]]; then
+  if [[ -z $(git log -1 --date=default -- $subdir) ]]; then
     error "The subdir '$subdir' is not part of this repo."
   fi
 }

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -8,6 +8,8 @@
 # Exit on any errors:
 set -e
 
+export FILTER_BRANCH_SQUELCH=1
+
 # Import Bash+ helper functions:
 SOURCE="$BASH_SOURCE"
 while [[ -h $SOURCE ]]; do


### PR DESCRIPTION
Use `git log --date=default` everywhere. The flag overrides the user's global log.date setting.