### PR TITLE
Use --date=default in all git log commands (Fixes #383)

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -767,7 +767,7 @@ subrepo:branch() {
         o "Create with content"
         local PREVIOUS_IFS=$IFS
         IFS=$'\n'
-        local author_info=( $(git log -1 --format=%ad%n%ae%n%an "$commit") )
+        local author_info=( $(git log -1 --date=default --format=%ad%n%ae%n%an "$commit") )
         IFS=$PREVIOUS_IFS
 
         # When we create new commits we leave the author information unchanged
@@ -775,7 +775,7 @@ subrepo:branch() {
         # This should be analog how cherrypicking is handled allowing git
         # to store both the original author but also the responsible committer
         # that created the local version of the commit and pushed it.
-        prev_commit=$(git log -n 1 --format=%B "$commit" |
+        prev_commit=$(git log -n 1 --date=default --format=%B "$commit" |
           GIT_AUTHOR_DATE="${author_info[0]}" \
           GIT_AUTHOR_EMAIL="${author_info[1]}" \
           GIT_AUTHOR_NAME="${author_info[2]}" \
@@ -1503,7 +1503,7 @@ assert-subdir-ready-for-init() {
     error "The subdir '$subdir' is already a subrepo."
   fi
   # Check that subdir is part of the repo
-  if [[ -z $(git log -1 -- $subdir) ]]; then
+  if [[ -z $(git log -1 --date=default -- $subdir) ]]; then
     error "The subdir '$subdir' is not part of this repo."
   fi
 }


### PR DESCRIPTION
Use git log --date=default everywhere. The flag overrides the user's global log.date setting.