### PR TITLE
provide activation script for Windows cmd

### DIFF
--- a/activate.bat
+++ b/activate.bat
@@ -1,0 +1,30 @@
+@echo off
+
+REM ------------------------------------------------------------------------------
+REM
+REM This is the `git-subrepo` cmd initialization script.
+REM
+REM This script turns on the `git-subrepo` Git subcommand for Windows command-line
+REM
+REM Just execute inside cmd.exe or another batch file:
+REM
+REM   path\to\git-subrepo\activate.bat
+REM
+REM ------------------------------------------------------------------------------
+
+
+where git.exe >nul 2>nul
+if %ERRORLEVEL% NEQ 0 (
+    echo could not find git in PATH
+    goto:end
+)
+
+if NOT "%GIT_SUBREPO_ROOT%" == "%~dp0" (
+    set "GIT_SUBREPO_ROOT=%~dp0"
+    set "PATH=%~dp0lib;%PATH%"
+)
+for /F "tokens=* USEBACKQ" %%F IN (`git subrepo --version`) do (
+    echo using version %%F in %GIT_SUBREPO_ROOT%
+)
+
+:end


### PR DESCRIPTION
`activate.bat` is the Windows cmd equivalent to `.rc` 
It first checks if the git command is available. Then sets environment variables `GIT_SUBREPO_ROOT` and `PATH`.
Multiple calls do not clutter up the `PATH` variable.