### PR TITLE
Fixes edge case with subrepo push failing on rebase

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -747,8 +747,8 @@ subrepo:branch() {
       [[ -n $prev_commit ]] && first_parent="-p $prev_commit"
       local second_parent=
       if [[ -z "$first_gitrepo_commit" ]]; then
-        first_gitrepo_commit="$gitrepo_commit"
-        second_parent="-p $gitrepo_commit"
+        first_gitrepo_commit="$subrepo_commit"
+        second_parent="-p $subrepo_commit"
       fi
 
       if [[ "$join_method" != "rebase" ]]; then


### PR DESCRIPTION
We have found that in some cases, a subrepo push fails when rebasing.

Note that our use case is to publish a subdirectory of a monorepo to a public subrepo. 
We only ever push, as there are never any other changes to the remote subrepo. 
The subrepo push is automated as part of the build and can cross with other developer commits.

We propose starting the subrepo branch from the most recent subrepo.commit value instead of from the subrepo.commit value that was current at the time of the first commit to be included in the branch.

A simplified example of the situation:

Parent repo log

    A -> B -> C -> D -> E -> F

    F: commit of .gitrepo file (subrepo.parent=D, subrepo.commit=C')
    E: commit in subrepo directory
    D: some commit
    C: commit in subrepo directory
    B: commit of .gitrepo file (subrepo.parent=A, subrepo.commit=A')
    A: commit in subrepo directory

    [Whilst pushing C to remote, D and E were committed to parent, 
    and then the result of the push was committed to parent in F]

Remote repo log

    A' -> C'

    C': commit corresponding to C
    A': commit corresponding to A

Now we want to push E to remote:

Before this change:
The rev-list used in subrepo:branch starts from D and gives [E, F].
commit E has .gitrepo file (subrepo.parent=A, subrepo.commit=A')
so the subrepo branch process starts from A', and produces:

    A' -> E''

    (F'' is filtered out as it is empty after .gitrepo is removed)
Note that C' has been omitted from the subrepo branch.
This can cause a conflict during rebase if E depends on C.

With this change:
We always use the most recent .gitrepo file (subrepo.parent=D, subrepo.commit=C')
to determine the initial commit for the subrepo branch.
Again, the rev-list used in subrepo:branch starts from D and gives [E, F].
This time, however, when processing E, which is the initial commit to the branch, 
the subrepo branch process starts from C', and produces:

    A' -> C' -> E''

which will always rebase successfully.