### PR TITLE
Allow test to run without a git checkout

### DIFF
--- a/test/setup
+++ b/test/setup
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
+# Set this locally for Windows:
+git config core.autocrlf input
+
 set -e
 
 # Set the GIT_SUBREPO_ROOT for testing.
 source $PWD/.rc
-
-# Set this locally for Windows:
-git config core.autocrlf input
 
 export BASHLIB="`
   find $PWD -type d |


### PR DESCRIPTION
set -e, which exits on command error, was set before calling git config
to set the environment for Windows machines.

Fixes #477