### PR TITLE
Feature/reset

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -37,6 +37,7 @@ git subrepo <command> <arguments> <options>
 Commands:
   clone     Clone a remote repository into a local subdirectory
   init      Turn a current subdirectory into a subrepo
+  reset     Reset subrepo performing a forced reclone
   pull      Pull upstream changes to the subrepo
   push      Push local subrepo changes upstream
 
@@ -177,6 +178,16 @@ main() {
 # subrepo:* worker functions are meant to be called internally and don't print
 # info to the user.
 #------------------------------------------------------------------------------
+
+command:reset() {
+  command-setup +subdir
+
+  local reclone_up_to_date=false
+  force_wanted=true
+  subrepo:clone
+
+  say "Subrepo '$subdir' reset to '$subrepo_remote' ($subrepo_branch)."
+}
 
 # `git subrepo clone <url> [<subdir>]` command:
 command:clone() {
@@ -1077,6 +1088,7 @@ get-command-options() {
 }
 
 options_help='all'
+options_reset='branch remote'
 options_branch='all fetch force'
 options_clean='ALL all force'
 options_clone='branch edit force message method'

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -180,12 +180,15 @@ main() {
 #------------------------------------------------------------------------------
 
 command:reset() {
-  command-setup +subdir
+  command-setup +subdir forced_commit
 
   local reclone_up_to_date=false
-  force_wanted=true
-  subrepo:clone
+  local force_wanted=true
+  if [ -n "$forced_commit" ]; then
+    forced_commit="$(git rev-parse "$forced_commit")"
+  fi
 
+  subrepo:clone
   say "Subrepo '$subdir' reset to '$subrepo_remote' ($subrepo_branch)."
 }
 
@@ -481,6 +484,9 @@ subrepo:clone() {
   if $force_wanted; then
     o "--force indicates a reclone."
     CALL subrepo:fetch
+    if [ -n "$forced_commit" ]; then
+        upstream_head_commit=$forced_commit
+    fi
     read-gitrepo-file
     o "Check if we already are up to date."
     if [[ $upstream_head_commit == $subrepo_commit ]]; then


### PR DESCRIPTION
This PR adds the 'git subrepo reset' subcommand.

It simply does a forced reclone on an existing subrepo. 
The remote and branch are taken from the .gitrepo file if not specified. You can optionally also specify a commit-ish reference.

Some people asked for something like this and I also sometimes need to set the subrepo to a certain state when something is wrong or I just need to switch back.
Since I'm not an  bash expert the code might not be perfect and I didn't provide any tests. But the scripts are well structured so I could easily implement it for myself. Would be happy to get some feedback.