### PR TITLE
Fix get-upstream-head-branch

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -1541,22 +1541,19 @@ add-subrepo() {
 
 # Determine the upstream's default head branch:
 get-upstream-head-branch() {
-  OUT=true RUN git ls-remote $subrepo_remote
-  local remotes="$output"
+  local remotes branch
+  OUT=true RUN git ls-remote --symref $subrepo_remote
+  remotes="$output"
   [[ -n $remotes ]] ||
-    error "Failed to 'git ls-remote $subrepo_remote'."
-  local commit="$(
+    error "Failed to 'git ls-remote --symref $subrepo_remote'."
+
+  # 'ref: refs/heads/master  HEAD'
+  branch="$(
     echo "$remotes" |
-    grep HEAD |
-    cut -f1
+    grep "^ref:" | grep 'HEAD$' | cut -f2 -d':' | cut -f1 |
+    head -n1
   )"
-  local branch="$(
-    echo "$remotes" |
-    grep -E "$commit[[:space:]]+refs/heads/" |
-    grep -v HEAD |
-    head -n1 |
-    cut -f2
-  )"
+  branch="${branch/ }"
   [[ $branch =~ refs/heads/ ]] ||
     error "Problem finding remote default head branch."
   output="${branch#refs/heads/}"

--- a/test/error.t
+++ b/test/error.t
@@ -162,7 +162,7 @@ clone-foo-and-bar
       cd $OWNER/bar
       catch git subrepo clone dummy-repo
     )" \
-    "git-subrepo: Command failed: 'git ls-remote dummy-repo'." \
+    "git-subrepo: Command failed: 'git ls-remote --symref dummy-repo'." \
     "Error OK: clone non-repo"
 }
 


### PR DESCRIPTION
When there are two branches pointing to the same commit, master and devel
for example, and origin/HEAD points to master, then it picked up the wrong
branch when doing `git subrepo clone`.
Fixes #494 
    
    % git ls-remote
    63ec5acd016d628e004735232f4a4b5b8d4e4df1        HEAD
    63ec5acd016d628e004735232f4a4b5b8d4e4df1        refs/heads/devel
    63ec5acd016d628e004735232f4a4b5b8d4e4df1        refs/heads/master
    
Adding --symref gets the branch name directly.
