### PR TITLE
Fix error "fatal: Not a valid object name: ''."

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -788,6 +788,7 @@ subrepo:branch() {
     if [[ -z "$prev_commit" ]]; then # i.e. there are no new reachable commits
       o "Create branch '$branch' for subrepo commit $subrepo_commit."
       prev_commit="$subrepo_commit"
+      first_gitrepo_commit="$subrepo_commit" # force neutralization of $filter to avoid unnecessary large range (see below)
     else
       o "Create branch '$branch' for this new commit set $prev_commit."
     fi

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -785,7 +785,12 @@ subrepo:branch() {
       fi
     done
 
-    o "Create branch '$branch' for this new commit set $prev_commit."
+    if [[ -z "$prev_commit" ]]; then # i.e. there are no new reachable commits
+      o "Create branch '$branch' for subrepo commit $subrepo_commit."
+      prev_commit="$subrepo_commit"
+    else
+      o "Create branch '$branch' for this new commit set $prev_commit."
+    fi
     RUN git branch "$branch" "$prev_commit"
   else
     o "No parent setting, use the subdir content."


### PR DESCRIPTION
# Problem

In case there are no (relevant) commits (e.g. directly after `git subrepo push`) which cause `subrepo:branch()` (i.e. on `git subrepo pull <subrepo>`) to fail with an git error message

> git-subrepo: Command failed: 'git branch subrepo/\<subrepo\> '.
> fatal: Not a valid object name: ''.

See issues #348, #350 and #424.

# Cause

This is because second parameter to `git branch` is an empty string as variable `prev_commit` has not been set. Thus, [branch creation](https://github.com/ingydotnet/git-subrepo/blob/a04d8c2e55c31931d66b5c92ef6d4fe4c59e3226/lib/git-subrepo#L789) fails in that case.

# Solution

To create the subrepo branch, nevertheless, it can be created on the cloned/pulled commit from `.gitrepo` file (per variable `subrepo_commit`) as there have not been any relevant changes.
Furthermore – to avoid unnecessary large range on the subsequent [call of `git filter-branch`](https://github.com/ingydotnet/git-subrepo/blob/a04d8c2e55c31931d66b5c92ef6d4fe4c59e3226/lib/git-subrepo#L800) – variable `first_gitrepo_commit` should be neutralized with `subrepo_commit` as well, so that variable `filter` results in an empty revision range.