### PR TITLE
Fix: broken zsh $fpath

### DIFF
--- a/share/enable-completion.sh
+++ b/share/enable-completion.sh
@@ -46,5 +46,5 @@ elif [[ ${ZSH_VERSION-} ]]; then
   # Prepend to `fpath` the path of the directory containing our zsh
   # completion script, so that our completion script will be hooked into the
   # zsh completion system.
-  fpath=("$GIT_SUBREPO_ROOT/share/zsh-completion" "$fpath")
+  fpath=("$GIT_SUBREPO_ROOT/share/zsh-completion" $fpath)
 fi


### PR DESCRIPTION
The `fpath=` line breaks my zsh $fpath. $fpath is not a string. It's an array of strings. So I unquote the `"$fpath"`.

I don't know why the line suddenly breaks my zsh (Today I update my zsh and its plugin system from zplug to zinit).

In the zsh manual it doesn't quote `$fpath`, so I think this is recommended.

http://zsh.sourceforge.net/Doc/Release/Functions.html
```sh
fpath=(~/myfuncs $fpath)
```

```console
% zsh --version
zsh 5.8 (x86_64-apple-darwin19.6.0)
```