### PR TITLE
[PR] Fix tests to support use of a default branch that is not "master"

### DIFF
--- a/test/issue29.t
+++ b/test/issue29.t
@@ -40,7 +40,7 @@ cd "$TMP"
   touch main1
   git add main1
   git commit -m "Initial main1"
-  git subrepo clone ../share share -b master
+  git subrepo clone ../share share -b "$DEFAULTBRANCH"
 ) > /dev/null
 
 # `subrepo clone` the share repo into main2:
@@ -49,7 +49,7 @@ cd "$TMP"
   touch main2
   git add main2
   git commit -m "Initial main2"
-  git subrepo clone ../share share -b master
+  git subrepo clone ../share share -b "$DEFAULTBRANCH"
 ) > /dev/null
 
 

--- a/test/issue95.t
+++ b/test/issue95.t
@@ -46,7 +46,7 @@ use Test::More
         touch feature
         git add feature
         git commit -m "feature added"
-        git checkout master
+        git checkout "$DEFAULTBRANCH"
     ) &> /dev/null
 
     # Commit directly to subrepo
@@ -89,7 +89,7 @@ use Test::More
             cd host
             git subrepo pull sub
     )" \
-        "Subrepo 'sub' pulled from '../sub' (master)."
+        "Subrepo 'sub' pulled from '../sub' ($DEFAULTBRANCH)."
 
 }
 

--- a/test/issue96.t
+++ b/test/issue96.t
@@ -81,15 +81,15 @@ use Test::More
             cd host
             git subrepo pull sub
     )" \
-        "Subrepo 'sub' pulled from '../sub' (master)."
+        "Subrepo 'sub' pulled from '../sub' ($DEFAULTBRANCH)."
 
     # Push subrepo changes
     # expected: successful push without conflicts
     is "$(
             cd host
-            git subrepo push sub -b master -u
+            git subrepo push sub -b "$DEFAULTBRANCH" -u
     )" \
-       "Subrepo 'sub' pushed to '../sub' (master)."
+       "Subrepo 'sub' pushed to '../sub' ($DEFAULTBRANCH)."
 
 done_testing 2
 

--- a/test/setup
+++ b/test/setup
@@ -33,6 +33,10 @@ mkdir -p "$UPSTREAM" "$OWNER" "$COLLAB"
 
 cp -r test/repo/{foo,bar,init} "$UPSTREAM/"
 
+DEFAULTBRANCH=$( git config --global --get init.defaultbranch || true )
+[[ -z $DEFAULTBRANCH ]] && DEFAULTBRANCH="master"
+export DEFAULTBRANCH
+
 ###
 # Test helper functions:
 ###


### PR DESCRIPTION
Three tests currently fail if the global default branch (`init.defaultbranch`) for git is set to use something other than `master`:

```
falken@mbp-ubuntu:~/src/git-subrepo$ uname -a
Linux mbp-ubuntu 5.4.0-65-generic #73-Ubuntu SMP Mon Jan 18 17:25:17 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
falken@mbp-ubuntu:~/src/git-subrepo$ git --version
git version 2.30.0
falken@mbp-ubuntu:~/src/git-subrepo$ git config --global -l | grep defaultbranch
init.defaultbranch=main
falken@mbp-ubuntu:~/src/git-subrepo$ make test
prove  test/
test/branch-all.t ................ ok   
[...]
test/init.t ...................... ok    
test/issue29.t ................... git-subrepo: Command failed: 'git fetch --no-tags --quiet ../share master'.
fatal: couldn't find remote ref master
test/issue29.t ................... No subtests run 
test/issue95.t ................... No subtests run 
test/issue96.t ................... 1/? #   Failed test at test/issue96.t line 83.
#     got: 'Subrepo 'sub' pulled from '../sub' (main).'
#   expected: 'Subrepo 'sub' pulled from '../sub' (master).'
test/issue96.t ................... Failed 1/2 subtests 
test/pull-all.t .................. ok   
[...] 
test/submodule.t ................. ok   

Test Summary Report
-------------------
test/issue29.t                 (Wstat: 0 Tests: 0 Failed: 0)
  Parse errors: No plan found in TAP output
test/issue95.t                 (Wstat: 0 Tests: 0 Failed: 0)
  Parse errors: No plan found in TAP output
test/issue96.t                 (Wstat: 0 Tests: 2 Failed: 1)
  Failed test:  1
Files=36, Tests=375, 47 wallclock secs ( 0.09 usr  0.06 sys + 35.07 cusr 11.11 csys = 46.33 CPU)
Result: FAIL
make: *** [Makefile:50: test] Error 1
```

By first retrieving any globally configured default branch (using `master` as a fallback if none is set), and using that branch name for the affected tests, all tests now successfully pass:

```
falken@mbp-ubuntu:~/src/git-subrepo$ git config --global -l | grep defaultbranch
init.defaultbranch=main
falken@mbp-ubuntu:~/src/git-subrepo$ make test
prove  test/
test/branch-all.t ................ ok   
[...]
test/init.t ...................... ok    
test/issue29.t ................... ok   
test/issue95.t ................... ok   
test/issue96.t ................... ok   
test/pull-all.t .................. ok   
[...]
test/submodule.t ................. ok   
All tests successful.
Files=36, Tests=378, 56 wallclock secs ( 0.13 usr  0.05 sys + 41.32 cusr 14.97 csys = 56.47 CPU)
Result: PASS
```