### PR TITLE
[PR] Pass --force to git add so a user's global .gitignore does not affect tests

### DIFF
--- a/test/setup
+++ b/test/setup
@@ -68,7 +68,7 @@ add-new-files() {
   local file
   for file in "$@"; do
     echo "new file $file" > "$file"
-    git add "$file"
+    git add --force "$file"
   done
   git commit --quiet -m "add new file: $file" &> /dev/null
 }


### PR DESCRIPTION
This PR fixes an issue ( #525 ) where a git-subrepo test would fail if the test happened to use a path or filespec which matched an entry in a user's global .gitignore file.

By passing `--force` to `git add`, test files are added to the test repositories regardless of any .gitignore file settings, and allows the tests to pass as expected.
