### PR TITLE
Fix for #534

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -955,7 +955,7 @@ subrepo:status() {
     local _worktree
     _worktree=$(
       git worktree list |
-        grep "$GIT_TMP/subrepo/$subdir"
+        grep "$GIT_TMP/subrepo/$subdir "
     ) || true
     if [[ $_worktree  ]]; then
       echo "  Worktree: $_worktree"
@@ -1564,7 +1564,7 @@ get-all-subrepos() {
 add-subrepo() {
   if ! $ALL_wanted; then
     for path in "${subrepos[@]}"; do
-      [[ $1 =~ ^$path ]] && return
+      [[ $1 =~ ^$path/ ]] && return
     done
   fi
   subrepos+=("$1")


### PR DESCRIPTION
Fix git subrepo status command for subrepos that share a common prefix. Closes #534.