### PR TITLE
Improve error message to give possible explanations about why the command failed

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -1576,7 +1576,7 @@ get-upstream-head-branch() {
   OUT=true RUN git ls-remote --symref "$subrepo_remote"
   remotes=$output
   [[ $remotes ]] ||
-    error "Failed to 'git ls-remote --symref $subrepo_remote'."
+    error "Failed to 'git ls-remote --symref $subrepo_remote'.\nPlease make sure the repository exists, is not empty, and that you have access rights to it."
 
   # 'ref: refs/heads/master  HEAD'
   branch=$(


### PR DESCRIPTION
I faced this error when trying to `git subrepo clone` a newly, empty repository, and it was not immediately obvious to me that the problem was that the repository was empty and thus has no branch.
I listed other possible reasons why the command would fail, not sure if there could be other ones.