### PR TITLE
Fix remote & branch being overwritten in .gitrepo without `--update` flag set

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -64,7 +64,7 @@ Options:
 h           Show the command summary
 help        Help overview
 version     Print the git-subrepo version number
- 
+
 a,all       Perform command on all current subrepos
 A,ALL       Perform command on all subrepos and subsubrepos
 b,branch=   Specify the upstream branch to push/pull/fetch
@@ -76,7 +76,7 @@ m,message=  Specify a commit message
 r,remote=   Specify the upstream remote to push/pull/fetch
 s,squash    Squash commits on push
 u,update    Add the --branch and/or --remote overrides to .gitrepo
- 
+
 q,quiet     Show minimal output
 v,verbose   Show verbose output
 d,debug     Show the actual commands used
@@ -1399,14 +1399,16 @@ update-gitrepo-file() {
     fi
   fi
 
-
-  # TODO: only update remote and branch if supplied and $update_wanted
-  if $newfile || [[ $update_wanted && $override_remote ]]; then
-    RUN git config --file="$gitrepo" subrepo.remote "$subrepo_remote"
-  fi
-
-  if $newfile || [[ $update_wanted && $override_branch ]]; then
-    RUN git config --file="$gitrepo" subrepo.branch "$subrepo_branch"
+  # only update remote and branch if supplied and $update_wanted
+  if $newfile || $update_wanted; then
+    if [[ $override_remote ]]; then
+      o "Update remote to $subrepo_remote"
+      RUN git config --file="$gitrepo" subrepo.remote "$subrepo_remote"
+    fi
+    if [[ $override_branch ]]; then
+      o "Update branch to $subrepo_branch"
+      RUN git config --file="$gitrepo" subrepo.branch "$subrepo_branch"
+    fi
   fi
 
   RUN git config --file="$gitrepo" subrepo.commit "$upstream_head_commit"

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -652,6 +652,9 @@ subrepo:push() {
   new_upstream_head_commit=$(git rev-parse "$branch_name")
   if ! $new_upstream; then
     if [[ $upstream_head_commit == "$new_upstream_head_commit" ]]; then
+      if $update_wanted ; then
+        update-gitrepo-file
+      fi
       OK=false
       CODE=-2
       return
@@ -1401,11 +1404,12 @@ update-gitrepo-file() {
 
   # only update remote and branch if supplied and $update_wanted
   if $newfile || $update_wanted; then
-    if [[ $override_remote ]]; then
+    if $newfile || [[ $override_remote ]]; then
       o "Update remote to $subrepo_remote"
       RUN git config --file="$gitrepo" subrepo.remote "$subrepo_remote"
     fi
-    if [[ $override_branch ]]; then
+
+    if $newfile || [[ $override_branch ]]; then
       o "Update branch to $subrepo_branch"
       RUN git config --file="$gitrepo" subrepo.branch "$subrepo_branch"
     fi

--- a/test/pull-new-branch.t
+++ b/test/pull-new-branch.t
@@ -29,9 +29,11 @@ gitrepo=$OWNER/foo/bar/.gitrepo
   test-gitrepo-field cmdver "$(git subrepo --version)"
 }
 
+# pull without update - keep the previous branch and remote in .gitrepo
+
 (
   cd "$OWNER/foo"
-  git subrepo pull bar -b branch1 -u
+  git subrepo pull bar -b branch1
 ) &> /dev/null || die
 
 {
@@ -39,6 +41,24 @@ gitrepo=$OWNER/foo/bar/.gitrepo
   bar_head_commit=$(cd "$OWNER/bar" || exit; git rev-parse HEAD)
   test-gitrepo-comment-block
   test-gitrepo-field remote "$UPSTREAM/bar"
+  test-gitrepo-field branch master
+  test-gitrepo-field commit "$bar_head_commit"
+  test-gitrepo-field parent "$foo_pull_commit"
+  test-gitrepo-field cmdver "$(git subrepo --version)"
+}
+
+# pull with update - use new branch and remote
+
+(
+  cd "$OWNER/foo"
+  git subrepo pull bar -b branch1 -r "$UPSTREAM/bar/./" -u
+) &> /dev/null || die
+
+{
+  foo_pull_commit=$(cd "$OWNER/foo" || exit; git rev-parse HEAD^)
+  bar_head_commit=$(cd "$OWNER/bar" || exit; git rev-parse HEAD)
+  test-gitrepo-comment-block
+  test-gitrepo-field remote "$UPSTREAM/bar/./"
   test-gitrepo-field branch branch1
   test-gitrepo-field commit "$bar_head_commit"
   test-gitrepo-field parent "$foo_pull_commit"

--- a/test/push-after-init.t
+++ b/test/push-after-init.t
@@ -22,7 +22,7 @@ use Test::More
 
 output=$(
   cd "$OWNER/init"
-  git subrepo push doc --remote=../upstream
+  git subrepo push doc --update --remote=../upstream
 )
 
 is "$output" "Subrepo 'doc' pushed to '../upstream' (master)." \

--- a/test/push-new-branch.t
+++ b/test/push-new-branch.t
@@ -20,6 +20,9 @@ clone-foo-and-bar
   add-new-files bar/FooBar
 ) &> /dev/null || die
 
+# shellcheck disable=2034
+gitrepo=$OWNER/foo/bar/.gitrepo
+
 # Do the subrepo push to another branch:
 {
   message=$(
@@ -31,19 +34,25 @@ clone-foo-and-bar
   is "$message" \
     "Subrepo 'bar' pushed to '$UPSTREAM/bar' (newbar)." \
     'First push message is correct '
+
+  test-gitrepo-field "branch" "master"
+  test-gitrepo-field "remote" "$UPSTREAM/bar"
 }
 
-# Do the subrepo push to another branch again:
+# Do the subrepo push to another branch again, with update:
 {
   message=$(
     cd "$OWNER/foo"
-    git subrepo push bar --branch newbar
+    git subrepo push bar --update --branch newbar --remote "$UPSTREAM/bar/."
   )
 
   # Test the output:
   is "$message" \
     "Subrepo 'bar' has no new commits to push." \
     'Second push message is correct'
+
+  test-gitrepo-field "branch" "newbar"
+  test-gitrepo-field "remote" "$UPSTREAM/bar/."
 }
 
 # Pull the changes from UPSTREAM/bar in OWNER/bar

--- a/test/setup
+++ b/test/setup
@@ -8,6 +8,11 @@ set -e
 # Set the GIT_SUBREPO_ROOT for testing.
 source "$PWD"/.rc
 
+# Unset variables that can change command output for testing
+unset GIT_SUBREPO_QUIET
+unset GIT_SUBREPO_VERBOSE
+unset GIT_SUBREPO_DEBUG
+
 # Get the location of this script
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 


### PR DESCRIPTION
The bug was that in this code:
```bash
if $newfile || [[ $update_wanted && $override_remote ]]; then
```
Command `if [[ $update_wanted ]]` will always succeed, even though `update_wanted` is `false`, because `[[` only checks that the string is not empty. Unfortunately, the tests didn't catch the fact that remote/branch were always updated due to this, so I've added some minimal checks that would fail before the fix.

cc @admorgan I've set the base to `release/0.4.5` as you asked of the other pending PRs, in case this could help release the fix sooner.