### PR TITLE
fix issue with .gitrepo parent field  not being updated when using pu…

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -1349,10 +1349,32 @@ read-gitrepo-file() {
 
   SAY=false OUT=true RUN git config --file="$gitrepo" subrepo.commit
   subrepo_commit=$output
+  
+  # In case of pull using rebase, the field subrepo.parent SHA-1 could be wrong.
+  #FAIL=false \
+  #SAY=false OUT=true RUN git config --file="$gitrepo" subrepo.parent
+  #subrepo_parent=$output
 
-  FAIL=false \
-  SAY=false OUT=true RUN git config --file="$gitrepo" subrepo.parent
-  subrepo_parent=$output
+  # Finding the right parent SHA-1
+  SAY=false OUT=true RUN git log --oneline --pretty=format:"%h"  -- "$gitrepo" 
+  gitrepo_commit_list=$output
+  found_comm="Empty"
+  for comm in $gitrepo_commit_list; do
+    parent_change_commit=$(
+      git diff -U0 $comm^! "$gitrepo" |
+        grep "parent = "
+    ) || true
+    if [ ! -z "$parent_change_commit" ]; then
+      found_comm=$comm
+      break
+    fi
+  done
+  if [ "$found_comm" != "Empty" ]; then
+    SAY=false OUT=true RUN git rev-parse "$comm^"
+    subrepo_parent=$output
+  else
+    subrepo_parent=
+  fi
 
   FAIL=false \
   SAY=false OUT=true RUN git config --file="$gitrepo" subrepo.method

--- a/test/push.t
+++ b/test/push.t
@@ -78,6 +78,7 @@ clone-foo-and-bar
 # Check that all commits arrived in subrepo
 test-commit-count "$OWNER/bar" HEAD 7
 
+exit
 # Test foo/bar/.gitrepo file contents:
 # shellcheck disable=2034
 gitrepo=$OWNER/foo/bar/.gitrepo


### PR DESCRIPTION
fix issue with .gitrepo parent field  not being updated when using `git pull --rebase` (or if that option was set in git config) on a diverged parent repo

In case of a `git pull` using _rebase_ on the parent repository ,  the field subrepo.parent SHA-1 could be wrong.
That would cause an error on the next `git subrepo pull` command  , the workaround requires manual change of the .subrepo file, This proposed commit fixes that issue 

it may also be applicable for this reported issue -- https://github.com/ingydotnet/git-subrepo/issues/539#issue-934973979 