### PR TITLE
Fix subrepo path comparison

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -1564,7 +1564,7 @@ get-all-subrepos() {
 add-subrepo() {
   if ! $ALL_wanted; then
     for path in "${subrepos[@]}"; do
-      [[ $1 =~ ^$path ]] && return
+      [[ $1 == ^$path ]] && return
     done
   fi
   subrepos+=("$1")


### PR DESCRIPTION
The path were compared like regex, the problem is that if we have 2 folders with the same starting name, the comparison would fail and one of the folder would be ignored (eg: `foobar` would be ignored if a previous `foo` subrepo existed)