### PR TITLE
Avoid stale worktree on push (2023 edition)

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -64,7 +64,7 @@ Options:
 h           Show the command summary
 help        Help overview
 version     Print the git-subrepo version number
- 
+
 a,all       Perform command on all current subrepos
 A,ALL       Perform command on all subrepos and subsubrepos
 b,branch=   Specify the upstream branch to push/pull/fetch
@@ -77,7 +77,7 @@ file=       Specify a commit message file
 r,remote=   Specify the upstream remote to push/pull/fetch
 s,squash    Squash commits on push
 u,update    Add the --branch and/or --remote overrides to .gitrepo
- 
+
 q,quiet     Show minimal output
 v,verbose   Show verbose output
 d,debug     Show the actual commands used
@@ -616,6 +616,8 @@ subrepo:push() {
     fi
 
     branch_name=subrepo/$subref
+    # We must make sure that a stale worktree is removed as well
+    worktree="$GIT_TMP/$branch_name"
     git:delete-branch "$branch_name"
 
     if $squash_wanted; then
@@ -654,9 +656,14 @@ subrepo:push() {
   new_upstream_head_commit=$(git rev-parse "$branch_name")
   if ! $new_upstream; then
     if [[ $upstream_head_commit == "$new_upstream_head_commit" ]]; then
-      OK=false
-      CODE=-2
-      return
+      # We must make sure that branch and worktree are removed (as they would
+      # later below, if there were any changes) to avoid having a stale worktree
+      # on further calls
+      if $branch_created; then
+        o "Remove branch '$branch_name'."
+        git:delete-branch "$branch_name"
+      fi
+      OK=false; CODE=-2; return
     fi
   fi
 

--- a/test/push-after-push-no-changes.t
+++ b/test/push-after-push-no-changes.t
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+
+source test/setup
+
+use Test::More
+
+clone-foo-and-bar
+subrepo-clone-bar-into-foo
+
+{
+  message=$(
+    cd "$OWNER/foo"
+    git subrepo push bar > /dev/null
+    add-new-files bar/Bar1
+    catch git subrepo push bar
+  )
+
+  is "$message" \
+    "Subrepo 'bar' pushed to '$UPSTREAM/bar' (master)." \
+    "Output OK: Check that 'push' after an empty push works."
+}
+
+done_testing 1
+
+teardown


### PR DESCRIPTION
Fixes #496

This is an updated pull request of the one @DanielBauten opened about 3 years ago (#497). I rebased it onto current master and provided a testcase.

@admorgan sorry for the ping, could you please take a look and merge if you're ok with the changes? I see that the last PR went dead for 2 years, and merging this would allow our company to adopt this tool instead of the awful submodules.

Thanks!