### PR TITLE
docs: Replace 404'ed hyperlink with archive.org equivalent

### DIFF
--- a/Intro.pod
+++ b/Intro.pod
@@ -78,7 +78,7 @@ Submodules tend to receive a lot of bad press. Here's some of it:
 
 =item * L<http://ayende.com/blog/4746/the-problem-with-git-submodules>
 
-=item * L<http://somethingsinistral.net/blog/git-submodules-are-probably-not-the-answer/>
+=item * L<https://web.archive.org/web/20171101202911/http://somethingsinistral.net/blog/git-submodules-are-probably-not-the-answer/>
 
 =item * L<http://codingkilledthecat.wordpress.com/2012/04/28/why-your-company-shouldnt-use-git-submodules/>
 

--- a/doc/intro-to-subrepo.swim
+++ b/doc/intro-to-subrepo.swim
@@ -61,7 +61,7 @@ article is about.
 Submodules tend to receive a lot of bad press. Here's some of it:
 
 * http://ayende.com/blog/4746/the-problem-with-git-submodules
-* http://somethingsinistral.net/blog/git-submodules-are-probably-not-the-answer/
+* https://web.archive.org/web/20171101202911/http://somethingsinistral.net/blog/git-submodules-are-probably-not-the-answer/
 * http://codingkilledthecat.wordpress.com/2012/04/28/why-your-company-shouldnt-use-git-submodules/
 
 A quick recap of some of the good and bad things about submodules:


### PR DESCRIPTION
Closes #478
Closes #187 (stale, has been fixed by #446)