### PR TITLE
Report git-subrepo's command info from non-standard installations

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -1703,10 +1703,10 @@ get-command-info() {
       command_commit=$(readlink "$lib/git-subrepo.d/commit")
     elif [[ $lib =~ / ]]; then
       lib=$(dirname "$lib")
-      if [[ -d $lib/.git ]]; then
+      if [[ -e $lib/.git ]]; then
         local remote
         remote=$(
-          GIT_DIR=$lib/.git git remote -v |
+          git -C $lib remote -v |
             grep '^origin' |
             head -n1 |
             cut -f2 |
@@ -1717,7 +1717,7 @@ get-command-info() {
         else
           local remote
           remote=$(
-            GIT_DIR=$lib/.git git remote -v |
+            git -C $lib remote -v |
               head -n1 |
               cut -f2 |
               cut -d ' ' -f1
@@ -1727,7 +1727,7 @@ get-command-info() {
           fi
         fi
         local commit
-        commit=$(GIT_DIR=$lib/.git git rev-parse --short HEAD)
+        commit=$(git -C $lib rev-parse --short HEAD)
         if [[ $commit ]]; then
           command_commit=$commit
         fi


### PR DESCRIPTION
When git-subrepo is invoked from a Git worktree or Git submodule, .git is a file, not a directory. As such it is necessary to traverse to the actual .git/ directory which is located elsewhere.

This patch teaches git-subrepo to use `git -C $lib` instead of `GIT_DIR=$lib/.git git`. Doing so places the burden on the Git executable to locate the canonical path of the install's .git/ directory.

While GIT_DIR has been around since Git v0.99, the `-C` option was "only" added in v1.8.5. Nevertheless, this does not impair git-subrepo as it already requires Git >= v2.7 due to its reliance on worktrees.