### PR TITLE
Adds the ability to --gpg-sign new commits to the upstream

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -77,6 +77,7 @@ file=       Specify a commit message file
 r,remote=   Specify the upstream remote to push/pull/fetch
 s,squash    Squash commits on push
 u,update    Add the --branch and/or --remote overrides to .gitrepo
+gpg-sign?   GPG-sign commits. The argument is optional and defaults to the committer identity; if specified, it must be stuck to the option without a space.
  
 q,quiet     Show minimal output
 v,verbose   Show verbose output
@@ -100,6 +101,8 @@ main() {
   local fetch_wanted=false      # Fetch requested before a command
   local squash_wanted=false     # Squash commits on push
   local update_wanted=false     # Update .gitrepo with --branch and/or --remote
+  local gpg_sign_wanted=false   # GPG-sign commits
+  local gpg_sign_keyid=         # Key id for GPG-sign
 
   local quiet_wanted=false      # Output should be quiet
   local verbose_wanted=false    # Output should be verbose
@@ -840,7 +843,12 @@ subrepo:branch() {
   local filter=$branch
   [[ $first_gitrepo_commit ]] && filter=$first_gitrepo_commit..$branch
   FAIL=false RUN git filter-branch -f --prune-empty --tree-filter \
-    "rm -f .gitrepo" "$filter"
+    "rm -f .gitrepo" -- "$filter" --first-parent
+
+  if $gpg_sign_wanted; then
+    o "Signing new commits"
+    FAIL=false RUN git filter-branch -f --commit-filter "git commit-tree --gpg-sign=$gpg_sign_keyid \"\$@\";" -- "$filter" --first-parent
+  fi
 
   git:create-worktree "$branch"
 
@@ -1046,6 +1054,8 @@ get-command-options() {
   [[ ${GIT_SUBREPO_VERBOSE-} ]] && verbose_wanted=true
   [[ ${GIT_SUBREPO_DEBUG-} ]] && debug_wanted=true
 
+  local original_opts=$@
+
   eval "$(
     echo "$GETOPT_SPEC" |
       git rev-parse --parseopt -- "$@" ||
@@ -1096,6 +1106,13 @@ get-command-options() {
           error "Commit msg file at $1 not found"
         fi
         shift ;;
+      --gpg-sign)
+        gpg_sign_wanted=true
+        local regex='--gpg-sign='
+        if [[ $original_opts =~ $regex ]]; then
+          gpg_sign_keyid=$1
+          shift
+        fi ;;
       --version)
         echo "$VERSION"
         exit ;;
@@ -1140,18 +1157,21 @@ get-command-options() {
       usage-error "Can't use '--update' without '--branch' or '--remote'."
     fi
   fi
+  if $gpg_sign_wanted; then
+    check_option gpg-sign
+  fi
 }
 
 options_help='all'
-options_branch='all fetch force'
+options_branch='all fetch force gpg-sign'
 options_clean='ALL all force'
 options_clone='branch edit force message method'
 options_config='force'
 options_commit='edit fetch force message'
 options_fetch='all branch remote'
 options_init='branch remote method'
-options_pull='all branch edit force message remote update'
-options_push='all branch force message remote squash update'
+options_pull='all branch edit force message remote update gpg-sign'
+options_push='all branch force message remote squash update gpg-sign'
 options_status='ALL all fetch'
 check_option() {
   local var=options_${command//-/_}


### PR DESCRIPTION
- Added new option `--gpg-sign` to `branch`, `pull`, `push` commands.
- Also fixes #613 as it is related for the feature to work correctly.