### PR TITLE
Fix issue where "git subrepo commit" incorrectly gives error "There is no worktree available".

### DIFF
--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -1231,7 +1231,7 @@ command-setup() {
     local _worktree
     _worktree=$(
       git worktree list |
-        grep "\[subrepo/$subdir\]" |
+        grep "\[subrepo/$subref\]" |
         cut -d ' ' -f1
     ) || true
     if [[ $command =~ ^(commit)$ && -z $_worktree ]]; then


### PR DESCRIPTION
Fix issue where `git subrepo commit` incorrectly gives error "There is no worktree available".

I encountered a merge conflict in a subrepo that has a name starting with a period character, `.obsidian`.

```
$> git subrepo pull .obsidian
The "git merge" command failed:

  Auto-merging plugins/obsidian-excalidraw-plugin/data.json
  CONFLICT (content): Merge conflict in plugins/obsidian-excalidraw-plugin/data.json
  Automatic merge failed; fix conflicts and then commit the result.

You will need to finish the pull by hand.
A new working tree has been created at .git/tmp/subrepo/%2eobsidian so that you can
resolve the conflicts shown in the output above.

This is the common conflict resolution workflow:

  1. cd .git/tmp/subrepo/%2eobsidian
  2. Resolve the conflicts (see "git status").
  3. "git add" the resolved files.
  4. git commit
  5. If there are more conflicts, restart at step 2.
  6. cd /mnt/c/Users/ReidG/data/repo/notes-vcm
  7. git subrepo commit .obsidian
See "git help merge" for details.

Alternatively, you can abort the pull and reset back to where you started:

  1. git subrepo clean .obsidian

See "git help subrepo" for more help.    
```

I follow all the recommended steps, resolving the conflicts and committing them.

But on the last step, the following error occurs.

```
$> git subrepo commit .obsidian 'subrepo/%2eobsidian'                     
git-subrepo: There is no worktree available, use the branch command first
```

I found that the `git subrepo commit` command uses the raw `subdir` variable to find the worktree, instead of the encoded `gitref` variable.

This PR changes `commit` to use the correct variable.