### PR TITLE
Debian patchset against 0.4.9 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SHELL := bash
+INSTALL ?= install
 
 # Make sure we have git:
 ifeq ($(shell which git),)
@@ -17,9 +18,11 @@ SHARE = share
 
 # Install variables:
 PREFIX ?= /usr/local
-INSTALL_LIB  ?= $(DESTDIR)$(shell git --exec-path)
+INSTALL_BIN  ?= $(PREFIX)/bin
+INSTALL_LIB  ?= $(PREFIX)/share/$(NAME)
 INSTALL_EXT  ?= $(INSTALL_LIB)/$(NAME).d
-INSTALL_MAN1 ?= $(DESTDIR)$(PREFIX)/share/man/man1
+INSTALL_MAN1 ?= $(PREFIX)/share/man/man1
+LINK_REL_DIR := $(shell realpath --relative-to=$(INSTALL_BIN) $(INSTALL_LIB))
 
 # Docker variables:
 DOCKER_TAG ?= 0.0.6
@@ -60,18 +63,22 @@ $(DOCKER_TESTS):
 
 # Install support:
 install:
-	install -d -m 0755 $(INSTALL_LIB)/
-	install -C -m 0755 $(LIB) $(INSTALL_LIB)/
-	install -d -m 0755 $(INSTALL_EXT)/
-	install -C -m 0644 $(EXTS) $(INSTALL_EXT)/
-	install -d -m 0755 $(INSTALL_MAN1)/
-	install -C -m 0644 $(MAN1)/$(NAME).1 $(INSTALL_MAN1)/
+	$(INSTALL) -d -m 0755 $(DESTDIR)$(INSTALL_LIB)/
+	$(INSTALL) -C -m 0755 $(LIB) $(DESTDIR)$(INSTALL_LIB)/
+	sed -i 's!^SUBREPO_EXT_DIR=.*!SUBREPO_EXT_DIR=$(INSTALL_EXT)!' $(DESTDIR)$(INSTALL_LIB)/$(NAME)
+	$(INSTALL) -d -m 0755 $(DESTDIR)$(INSTALL_BIN)
+	ln -s $(LINK_REL_DIR)/$(NAME) $(DESTDIR)$(INSTALL_BIN)/$(NAME)
+	$(INSTALL) -d -m 0755 $(DESTDIR)$(INSTALL_EXT)/
+	$(INSTALL) -C -m 0644 $(EXTS) $(DESTDIR)$(INSTALL_EXT)/
+	$(INSTALL) -d -m 0755 $(DESTDIR)$(INSTALL_MAN1)/
+	$(INSTALL) -C -m 0644 $(MAN1)/$(NAME).1 $(DESTDIR)$(INSTALL_MAN1)/
 
 # Uninstall support:
 uninstall:
-	rm -f $(INSTALL_LIB)/$(NAME)
-	rm -fr $(INSTALL_EXT)
-	rm -f $(INSTALL_MAN1)/$(NAME).1
+	rm -f $(DESTDIR)$(INSTALL_BIN)/$(NAME)
+	rm -fr $(DESTDIR)$(INSTALL_EXT)
+	rm -fr $(DESTDIR)$(INSTALL_LIB)
+	rm -f $(DESTDIR)$(INSTALL_MAN1)/$(NAME).1
 
 env:
 	@echo "export PATH=\"$$PWD/lib:\$$PATH\""

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ compgen: force
 	    $(SHARE)/zsh-completion/_git-subrepo
 
 clean:
-	rm -fr tmp test/tmp
+	rm -fr tmp test/tmp test/repo
 
 define docker-make-test
 	docker run --rm \

--- a/lib/git-subrepo
+++ b/lib/git-subrepo
@@ -12,21 +12,8 @@ set -e
 export FILTER_BRANCH_SQUELCH_WARNING=1
 
 # Import Bash+ helper functions:
-SOURCE=${BASH_SOURCE[0]}
-while [[ -h $SOURCE ]]; do
-  DIR=$( cd -P "$( dirname "$SOURCE" )" && pwd )
-  SOURCE=$(readlink "$SOURCE")
-  [[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE
-done
-SOURCE_DIR=$(dirname "$SOURCE")
-
-if [[ -z $GIT_SUBREPO_ROOT ]]; then
-  # If `make install` installation used:
-  source "${SOURCE_DIR}/git-subrepo.d/bash+.bash"
-else
-  # If `source .rc` method used:
-  source "${SOURCE_DIR}/../ext/bashplus/lib/bash+.bash"
-fi
+SUBREPO_EXT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/git-subrepo.d" # replaced by `make install`
+source "${SUBREPO_EXT_DIR}/bash+.bash"
 bash+:import :std can version-check
 
 
@@ -396,7 +383,7 @@ command:config() {
 
 # Launch the manpage viewer:
 command:help() {
-  source "${SOURCE_DIR}/git-subrepo.d/help-functions.bash"
+  source "${SUBREPO_EXT_DIR}/help-functions.bash"
   local cmd=${command_arguments[0]}
   if [[ $cmd ]]; then
     if can "help:$cmd"; then
@@ -1992,7 +1979,7 @@ OK() {
 usage-error() {
   local msg="git-subrepo: $1" usage=
   if [[ $GIT_SUBREPO_TEST_ERRORS != true ]]; then
-    source "${SOURCE_DIR}/git-subrepo.d/help-functions.bash"
+    source "${SUBREPO_EXT_DIR}/help-functions.bash"
     if can "help:$command"; then
       msg=$'\n'"$msg"$'\n'"$("help:$command")"$'\n'
     fi

--- a/test/clone.t
+++ b/test/clone.t
@@ -10,7 +10,7 @@ clone-foo-and-bar
 
 (
   mkdir -p "$OWNER/empty"
-  git init "$OWNER/empty"
+  git init --initial-branch=$DEFAULTBRANCH "$OWNER/empty"
 )
 
 # Test that the repos look ok:

--- a/test/config.t
+++ b/test/config.t
@@ -13,6 +13,9 @@ gitrepo=$OWNER/init/doc/.gitrepo
 
 (
   cd "$OWNER/init"
+  git config user.email "ini@ini"
+  git config user.name "IniUser"
+  git config init.defaultBranch $DEFAULTBRANCH
   git subrepo init doc
 ) > /dev/null
 

--- a/test/init.t
+++ b/test/init.t
@@ -22,6 +22,9 @@ gitrepo=$OWNER/init/doc/.gitrepo
 
 output=$(
   cd "$OWNER/init"
+  git config user.email "ini@ini"
+  git config user.name "IniUser"
+  git config init.defaultBranch $DEFAULTBRANCH
   git subrepo init doc
 )
 
@@ -48,6 +51,9 @@ rm -fr "$OWNER/init"
 git clone "$UPSTREAM/init" "$OWNER/init" &>/dev/null
 (
   cd "$OWNER/init"
+  git config user.email "ini@ini"
+  git config user.name "IniUser"
+  git config init.defaultBranch $DEFAULTBRANCH
   git subrepo init doc -r git@github.com:user/repo -b foo -M rebase
 ) >/dev/null
 

--- a/test/issue29.t
+++ b/test/issue29.t
@@ -18,14 +18,16 @@ cd "$TMP"
 # Make 3 new repos:
 (
   mkdir share main1 main2
-  git init share
-  git init main1
-  git init main2
+  git init --initial-branch=$DEFAULTBRANCH share
+  git init --initial-branch=$DEFAULTBRANCH main1
+  git init --initial-branch=$DEFAULTBRANCH main2
 ) > /dev/null
 
 # Add an empty 'readme' to the share repo:
 (
   cd share
+  git config user.name "ShrUser"
+  git config user.email "shr@ma1"
   echo '* text eol=lf' > .gitattributes
   touch readme
   git add readme .gitattributes
@@ -37,6 +39,8 @@ cd "$TMP"
 # `subrepo clone` the share repo into main1:
 (
   cd main1
+  git config user.name "Ma1User"
+  git config user.email "ma1@ma1"
   touch main1
   git add main1
   git commit -m "Initial main1"
@@ -46,6 +50,8 @@ cd "$TMP"
 # `subrepo clone` the share repo into main2:
 (
   cd main2
+  git config user.name "Ma2User"
+  git config user.email "ma2@ma2"
   touch main2
   git add main2
   git commit -m "Initial main2"

--- a/test/issue95.t
+++ b/test/issue95.t
@@ -12,13 +12,15 @@ use Test::More
     # Make two new repos
     (
         mkdir host sub
-        git init host
-        git init sub
+        git init --initial-branch=$DEFAULTBRANCH host
+        git init --initial-branch=$DEFAULTBRANCH sub
     ) > /dev/null
 
     # Initialize host repo
     (
         cd host
+        git config user.name "HstUser"
+        git config user.email "hst@hst"
         touch host
         git add host
         git commit -m "host initial commit"
@@ -27,7 +29,8 @@ use Test::More
     # Initialize sub repo
     (
         cd sub
-        git init
+        git config user.name "SubUser"
+        git config user.email "sub@sub"
         touch subrepo
         git add subrepo
         git commit -m "subrepo initial commit"

--- a/test/issue96.t
+++ b/test/issue96.t
@@ -11,13 +11,15 @@ use Test::More
     # Make two new repos
     (
         mkdir host sub
-        git init host
-        git init sub
+        git init --initial-branch=$DEFAULTBRANCH host
+        git init --initial-branch=$DEFAULTBRANCH sub
     ) > /dev/null
 
     # Initialize host repo
     (
         cd host
+        git config user.name "HstUser"
+        git config user.email "hst@hst"
         touch host
         git add host
         git commit -m "host initial commit"
@@ -26,7 +28,8 @@ use Test::More
     # Initialize sub repo
     (
         cd sub
-        git init
+        git config user.name "SubUser"
+        git config user.email "sub@sub"
         touch subrepo
         git add subrepo
         git commit -m "subrepo initial commit"

--- a/test/push-after-init.t
+++ b/test/push-after-init.t
@@ -12,12 +12,18 @@ use Test::More
 (
   mkdir -p "$OWNER/init"
   cd "$OWNER/init"
-  git init
+  git init --initial-branch=$DEFAULTBRANCH
+  git config user.name "IniUser"
+  git config user.email "ini@ini"
   mkdir doc
   add-new-files doc/FooBar
   git subrepo init doc || die
   mkdir ../upstream
-  git init --bare ../upstream || die
+  git init --initial-branch=$DEFAULTBRANCH --bare ../upstream || die
+  cd ../upstream
+  git config user.name "UpsUser"
+  git config user.email "ups@ups"
+  cd -
 ) &> /dev/null
 
 output=$(

--- a/test/setup
+++ b/test/setup
@@ -1,18 +1,25 @@
 #!/usr/bin/env bash
 
-# Set this locally for Windows:
-git config core.autocrlf input
-
 set -e
 
-# Set the GIT_SUBREPO_ROOT for testing.
-source "$PWD"/.rc
+export LC_ALL=C.UTF-8
 
 # Get the location of this script
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
+# Running tests depends on the whole project being git initialized.
+# So, git initialize the project, if necessary.
+if [ ! -d "${SCRIPT_DIR}/../.git" ]; then
+	git init -b master .
+	git config user.email "you@you"
+	git config user.name "YouUser"
+	git add .
+	git commit -a -m"Initial commit"
+	git config --list
+fi
+
 BASHLIB=$(
-  find "$PWD"/ -type d -name bin -o -type d -name lib | tr '\n' ':'
+  find "$PWD"/ -type d -name bin -o -type d -name lib | grep -v "\/\.pc\/" | tr '\n' ':'
 )
 export BASHLIB
 
@@ -46,17 +53,17 @@ clone-foo-and-bar() {
     git clone "$UPSTREAM/foo" "$OWNER/foo"
     (
         cd "$OWNER/foo"
-        git config core.autocrlf input
         git config user.name "FooUser"
         git config user.email "foo@foo"
+        git config init.defaultBranch $DEFAULTBRANCH
     )
     # bar will act as the subrepo
     git clone "$UPSTREAM/bar" "$OWNER/bar"
     (
         cd "$OWNER/bar"
-        git config core.autocrlf input
         git config user.name "BarUser"
         git config user.email "bar@bar"
+        git config init.defaultBranch $DEFAULTBRANCH
     )
   ) &> /dev/null || die
 }

--- a/test/setup
+++ b/test/setup
@@ -18,6 +18,18 @@ if [ ! -d "${SCRIPT_DIR}/../.git" ]; then
 	git config --list
 fi
 
+# Generate additional testing git repos, if not already present.
+mkdir -p  "${SCRIPT_DIR}/repo"
+if [ ! -d "${SCRIPT_DIR}/repo/bar" ]; then
+	"${SCRIPT_DIR}/genbar" "${SCRIPT_DIR}/repo"
+fi
+if [ ! -d "${SCRIPT_DIR}/repo/foo" ]; then
+	"${SCRIPT_DIR}/genfoo" "${SCRIPT_DIR}/repo"
+fi
+if [ ! -d "${SCRIPT_DIR}/repo/init" ]; then
+	"${SCRIPT_DIR}/geninit" "${SCRIPT_DIR}/repo"
+fi
+
 BASHLIB=$(
   find "$PWD"/ -type d -name bin -o -type d -name lib | grep -v "\/\.pc\/" | tr '\n' ':'
 )

--- a/test/setup
+++ b/test/setup
@@ -15,8 +15,17 @@ if [ ! -d "${SCRIPT_DIR}/../.git" ]; then
 	git config user.name "YouUser"
 	git add .
 	git commit -a -m"Initial commit"
-	git config --list
 fi
+
+# Disable any GIT configuration set outside this 'git-subrepo' project.
+# This prevents specific build environment GIT settings to influence
+# execution of the test suite.
+export XDG_CONFIG_HOME=$SCRIPT_DIR
+export HOME=$SCRIPT_DIR
+export GIT_CONFIG_NOSYSTEM=1
+# To be able to view current GIT confirguration during tests execution,
+# run the test suite by adding the '-v' option to the prove command.
+git config --list
 
 # Generate additional testing git repos, if not already present.
 mkdir -p  "${SCRIPT_DIR}/repo"


### PR DESCRIPTION
Commits of this pull request represent the state of debian patches needed for the 0.4.9 upstream release. There is actually another patch, which fixes the broken test 'push-after-init' in 0.4.9, but that had already been fixed upstream after 0.4.9 (https://github.com/ingydotnet/git-subrepo/commit/b00d41ba7ca50ca3cb52d141b5de8eeb9500a42b, https://github.com/ingydotnet/git-subrepo/commit/57de7d64ddf4c61ee2063f964ca766b535f04d6a).

There is still an open question about howto address Windows compatibility in some of the patches.
Anyway, here is the summary of what we want to achieve:

    fixing bash-completion integration with git
    running tests in predictable git environment
    generating test git repos instead of commited binaries

p.s.
I accidently closed original PR637, since i had to reset my master branch to latest upstream.