### PR TITLE
Updated GPLv2 notice mostly to fix old fsf address

### DIFF
--- a/share/git-completion.bash
+++ b/share/git-completion.bash
@@ -65,17 +65,16 @@ __gitdir ()
 #
 #   This program is free software; you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
-#   the Free Software Foundation; either version 2, or (at your option)
-#   any later version.
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
 #
 #   This program is distributed in the hope that it will be useful,
 #   but WITHOUT ANY WARRANTY; without even the implied warranty of
 #   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #   GNU General Public License for more details.
 #
-#   You should have received a copy of the GNU General Public License
-#   along with this program; if not, write to the Free Software Foundation,
-#   Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, see <https://www.gnu.org/licenses/>.
 #
 #   The latest version of this software can be obtained here:
 #


### PR DESCRIPTION
Please consider changing the GPLv2 notice in share/git-completion.bash to comply with its current wording (changed FSF address).

best regards, Samo